### PR TITLE
Fix hard crash when printing nil value, change mod path for mac systems

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -43,8 +43,11 @@ impl Lovely {
 
         let args = std::env::args().skip(1).collect::<Vec<_>>();
         let mut opts = Options::new(args.iter().map(String::as_str));
-    
+        #[cfg(target_os = "windows")]
         let mut mod_dir = dirs::config_dir().unwrap().join("Balatro\\Mods");
+        #[cfg(target_os = "macos")]
+        let mut mod_dir = dirs::config_dir().unwrap().join("Balatro/Mods");
+        
         let mut is_vanilla = false;
     
         while let Some(opt) = opts.next_arg().expect("Failed to parse argument.") {

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -43,10 +43,10 @@ impl Lovely {
 
         let args = std::env::args().skip(1).collect::<Vec<_>>();
         let mut opts = Options::new(args.iter().map(String::as_str));
-        #[cfg(target_os = "windows")]
-        let mut mod_dir = dirs::config_dir().unwrap().join("Balatro\\Mods");
-        #[cfg(target_os = "macos")]
-        let mut mod_dir = dirs::config_dir().unwrap().join("Balatro/Mods");
+        let mut mod_dir = dirs::config_dir()
+            .unwrap()
+            .join("Balatro")
+            .join("Mods");
         
         let mut is_vanilla = false;
     

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -152,6 +152,10 @@ pub unsafe extern "C" fn override_print(state: *mut LuaState) -> isize {
     for i in 0..argc {
         let mut str_len = 0_isize; 
         let arg_str = lua_tolstring(state, -1, &mut str_len);
+        if arg_str.is_null() {
+            out.push_str("[GAME] nil");
+            continue;
+        }
         
         let str_buf = slice::from_raw_parts(arg_str as *const u8, str_len as _);
         let arg_str = String::from_utf8_lossy(str_buf);


### PR DESCRIPTION
Ran into the same issue as someone else, this fixed it on my end.
Also now uses / for mods folder on Mac.