### PR TITLE
Improved toml errors

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -236,7 +236,7 @@ impl PatchTable {
                     .unwrap_or_else(|e| panic!("Failed to read patch file at {patch_file:?}:\n{e:?}"));
 
                 toml::from_str(&str)
-                    .unwrap_or_else(|e| panic!("Failed to parse patch file at {patch_file:?}:\n{e:?}"))
+                    .unwrap_or_else(|e| panic!("Failed to parse patch file at {patch_file:?}:\n{}", e.to_string()))
             };
 
             // For each patch, map relative paths onto absolute paths, rooted within each's mod directory.


### PR DESCRIPTION
This makes toml errors way easier to read.

Before:
![image](https://github.com/ethangreen-dev/lovely-injector/assets/33164598/e3b38209-e98a-4e70-a751-8eb546cb92eb)

After:
![image](https://github.com/ethangreen-dev/lovely-injector/assets/33164598/23fd02e5-b4e1-4445-9c5a-7fdf89fa2e2d)
