### PR TITLE
Mac: use the name of the enclosing .app for the mod directory

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -41,12 +41,25 @@ impl Lovely {
 
         let args = std::env::args().skip(1).collect::<Vec<_>>();
         let mut opts = Options::new(args.iter().map(String::as_str));
-        let game_name = env::current_exe()
-            .expect("Failed to get the path of the current executable.")
-            .file_stem()
-            .expect("Failed to get file_stem component of current executable path.")
-            .to_string_lossy()
-            .replace(".", "_");
+        let cur_exe = env::current_exe()
+            .expect("Failed to get the path of the current executable.");
+        let game_name = if env::consts::OS == "macos" {
+            cur_exe
+                .parent().and_then(Path::parent).and_then(Path::parent)
+                .expect("Couldn't find parent .app of current executable path")
+                .file_name()
+                .expect("Failed to get file_name of parent directory of current executable")
+                .to_string_lossy()
+                .strip_suffix(".app")
+                .expect("Parent directory of current executable path was not an .app")
+                .replace(".", "_")
+        } else {
+            cur_exe
+                .file_stem()
+                .expect("Failed to get file_stem component of current executable path.")
+                .to_string_lossy()
+                .replace(".", "_")
+        };
         let mut mod_dir = dirs::config_dir()
             .unwrap()
             .join(game_name)


### PR DESCRIPTION
Currently just takes the parent 3 levels up, which is hacky. it works for now