### PR TITLE
Implement better patches

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -435,7 +435,7 @@ impl PatchTable {
 
         let mut patched_lines = {
             let inner = rope.to_string();
-            inner.split('\n').map(String::from).collect_vec()
+            inner.split_inclusive('\n').map(String::from).collect_vec()
         };
 
         // Apply variable interpolation.
@@ -445,7 +445,7 @@ impl PatchTable {
             patch::vars::apply_var_interp(line, &self.vars);
         }
 
-        let patched = patched_lines.join("\n");
+        let patched = patched_lines.concat();
 
         if patch_count == 1 {
             info!("Applied 1 patch to '{target}'");

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -162,7 +162,7 @@ impl Lovely {
         }
 
         // Prepare buffer for patching (Check and remove the last byte if it is a null terminator)
-        let last_byte = *buf_ptr.add((size - 1) as usize);
+        let last_byte = *buf_ptr.offset(size - 1);
         let actual_size = if last_byte == 0 { size - 1 } else { size };
 
         // Convert the buffer from cstr ptr, to byte slice, to utf8 str.

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -4,24 +4,24 @@ use core::slice;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
+use std::path::{Path, PathBuf};
 use std::sync::Once;
 use std::time::Instant;
 use std::{env, fs};
-use std::path::{Path, PathBuf};
 
 use log::*;
 
-use itertools::Itertools;
-use getargs::{Arg, Options};
-use patch::{Patch, PatchFile, Priority};
 use crop::Rope;
+use getargs::{Arg, Options};
+use itertools::Itertools;
+use patch::{Patch, PatchFile, Priority};
 use sha2::{Digest, Sha256};
 use sys::LuaState;
 
 pub mod chunk_vec_cursor;
-pub mod sys;
 pub mod log;
 pub mod patch;
+pub mod sys;
 
 type LoadBuffer = dyn Fn(*mut LuaState, *const u8, isize, *const u8) -> u32 + Send + Sync + 'static;
 
@@ -40,11 +40,13 @@ impl Lovely {
 
         let args = std::env::args().skip(1).collect_vec();
         let mut opts = Options::new(args.iter().map(String::as_str));
-        let cur_exe = env::current_exe()
-            .expect("Failed to get the path of the current executable.");
+        let cur_exe =
+            env::current_exe().expect("Failed to get the path of the current executable.");
         let game_name = if env::consts::OS == "macos" {
             cur_exe
-                .parent().and_then(Path::parent).and_then(Path::parent)
+                .parent()
+                .and_then(Path::parent)
+                .and_then(Path::parent)
                 .expect("Couldn't find parent .app of current executable path")
                 .file_name()
                 .expect("Failed to get file_name of parent directory of current executable")
@@ -59,10 +61,7 @@ impl Lovely {
                 .to_string_lossy()
                 .replace(".", "_")
         };
-        let mut mod_dir = dirs::config_dir()
-            .unwrap()
-            .join(game_name)
-            .join("Mods");
+        let mut mod_dir = dirs::config_dir().unwrap().join(game_name).join("Mods");
 
         let log_dir = mod_dir.join("lovely").join("log");
 
@@ -75,7 +74,9 @@ impl Lovely {
 
         while let Some(opt) = opts.next_arg().expect("Failed to parse argument.") {
             match opt {
-                Arg::Long("mod-dir") => mod_dir = opts.value().map(PathBuf::from).unwrap_or(mod_dir),
+                Arg::Long("mod-dir") => {
+                    mod_dir = opts.value().map(PathBuf::from).unwrap_or(mod_dir)
+                }
                 Arg::Long("vanilla") => is_vanilla = true,
                 _ => (),
             }
@@ -115,17 +116,20 @@ impl Lovely {
         }
 
         info!("Using mod directory at {mod_dir:?}");
-        let patch_table = PatchTable::load(&mod_dir)
-            .with_loadbuffer(loadbuffer);
+        let patch_table = PatchTable::load(&mod_dir).with_loadbuffer(loadbuffer);
 
         let dump_dir = mod_dir.join("lovely").join("dump");
         if dump_dir.is_dir() {
             info!("Cleaning up dumps directory at {dump_dir:?}");
-            fs::remove_dir_all(&dump_dir)
-                .unwrap_or_else(|e| panic!("Failed to recursively delete dumps directory at {dump_dir:?}: {e:?}"));
+            fs::remove_dir_all(&dump_dir).unwrap_or_else(|e| {
+                panic!("Failed to recursively delete dumps directory at {dump_dir:?}: {e:?}")
+            });
         }
 
-        info!("Initialization complete in {}ms", start.elapsed().as_millis());
+        info!(
+            "Initialization complete in {}ms",
+            start.elapsed().as_millis()
+        );
 
         Lovely {
             mod_dir,
@@ -142,7 +146,13 @@ impl Lovely {
     /// This function is unsafe because
     /// - It interacts and manipulates memory directly through native pointers
     /// - It interacts, calls, and mutates native lua state through native pointers
-    pub unsafe fn apply_buffer_patches(&self, state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8) -> u32 {
+    pub unsafe fn apply_buffer_patches(
+        &self,
+        state: *mut LuaState,
+        buf_ptr: *const u8,
+        size: isize,
+        name_ptr: *const u8,
+    ) -> u32 {
         // Install native function overrides.
         self.rt_init.call_once(|| {
             let closure = sys::override_print as *const c_void;
@@ -153,8 +163,9 @@ impl Lovely {
             self.patch_table.inject_metadata(state);
         });
 
-        let name = CStr::from_ptr(name_ptr as _).to_str()
-            .unwrap_or_else(|e| panic!("The byte sequence at {name_ptr:x?} is not a valid UTF-8 string: {e:?}"));
+        let name = CStr::from_ptr(name_ptr as _).to_str().unwrap_or_else(|e| {
+            panic!("The byte sequence at {name_ptr:x?} is not a valid UTF-8 string: {e:?}")
+        });
 
         // Stop here if no valid patch exists for this target.
         if !self.patch_table.needs_patching(name) {
@@ -169,12 +180,14 @@ impl Lovely {
         let buf = slice::from_raw_parts(buf_ptr, actual_size as _);
         let buf_str = CString::new(buf)
             .unwrap_or_else(|e| panic!("The byte buffer '{buf:?}' for target {name} contains a non-terminating null char: {e:?}"));
-        let buf_str = buf_str.to_str()
-            .unwrap_or_else(|e| panic!("The byte buffer '{buf:?}' for target {name} contains invalid UTF-8: {e:?}"));
+        let buf_str = buf_str.to_str().unwrap_or_else(|e| {
+            panic!("The byte buffer '{buf:?}' for target {name} contains invalid UTF-8: {e:?}")
+        });
 
         let patched = self.patch_table.apply_patches(name, buf_str, state);
 
-        let patch_dump = self.mod_dir
+        let patch_dump = self
+            .mod_dir
             .join("lovely")
             .join("dump")
             .join(name.replace('@', ""));
@@ -215,7 +228,9 @@ impl PatchTable {
     /// - MOD_DIR/lovely/*.toml
     pub fn load(mod_dir: &Path) -> PatchTable {
         let mod_dirs = fs::read_dir(mod_dir)
-            .unwrap_or_else(|e| panic!("Failed to read from mod directory within {mod_dir:?}:\n{e:?}"))
+            .unwrap_or_else(|e| {
+                panic!("Failed to read from mod directory within {mod_dir:?}:\n{e:?}")
+            })
             .filter_map(|x| x.ok())
             .filter(|x| x.path().is_dir())
             .map(|x| x.path())
@@ -243,7 +258,9 @@ impl PatchTable {
 
                 if lovely_dir.is_dir() {
                     let mut subfiles = fs::read_dir(&lovely_dir)
-                        .unwrap_or_else(|_| panic!("Failed to read from lovely directory at '{lovely_dir:?}'."))
+                        .unwrap_or_else(|_| {
+                            panic!("Failed to read from lovely directory at '{lovely_dir:?}'.")
+                        })
                         .filter_map(|x| x.ok())
                         .map(|x| x.path())
                         .filter(|x| x.is_file())
@@ -272,8 +289,9 @@ impl PatchTable {
             };
 
             let mut patch_file: PatchFile = {
-                let str = fs::read_to_string(&patch_file)
-                    .unwrap_or_else(|e| panic!("Failed to read patch file at {patch_file:?}:\n{e:?}"));
+                let str = fs::read_to_string(&patch_file).unwrap_or_else(|e| {
+                    panic!("Failed to read patch file at {patch_file:?}:\n{e:?}")
+                });
 
                 // Handle invalid fields in a non-explosive way.
                 let ignored_key_callback = |key: serde_ignored::Path| {
@@ -363,7 +381,12 @@ impl PatchTable {
     /// Apply one or more patches onto the target's buffer.
     /// # Safety
     /// Unsafe due to internal unchecked usages of raw lua state.
-    pub unsafe fn apply_patches(&self, target: &str, buffer: &str, lua_state: *mut LuaState) -> String {
+    pub unsafe fn apply_patches(
+        &self,
+        target: &str,
+        buffer: &str,
+        lua_state: *mut LuaState,
+    ) -> String {
         let target = target.strip_prefix('@').unwrap_or(target);
 
         let module_patches = self
@@ -380,7 +403,7 @@ impl PatchTable {
             .iter()
             .filter_map(|(x, prio)| match x {
                 Patch::Copy(patch) => Some((patch, prio)),
-                _ => None
+                _ => None,
             })
             .sorted_by_key(|(_, &prio)| prio)
             .map(|(x, _)| x);
@@ -389,7 +412,7 @@ impl PatchTable {
             .iter()
             .filter_map(|(x, prio)| match x {
                 Patch::Pattern(_) | Patch::Regex(_) => Some((x, prio)),
-                _ => None
+                _ => None,
             })
             .sorted_by_key(|(_, &prio)| prio)
             .map(|(x, _)| x);
@@ -401,9 +424,7 @@ impl PatchTable {
         // Apply module injection patches.
         let loadbuffer = self.loadbuffer.unwrap();
         for patch in module_patches {
-            let result = unsafe {
-                patch.apply(target, lua_state, &loadbuffer)
-            };
+            let result = unsafe { patch.apply(target, lua_state, &loadbuffer) };
 
             if result {
                 patch_count += 1;
@@ -423,13 +444,13 @@ impl PatchTable {
                     if patch.apply(target, &mut rope) {
                         patch_count += 1;
                     }
-                },
+                }
                 Patch::Regex(patch) => {
                     if patch.apply(target, &mut rope) {
                         patch_count += 1;
                     }
-                },
-                _ => unreachable!()
+                }
+                _ => unreachable!(),
             }
         }
 
@@ -458,8 +479,6 @@ impl PatchTable {
         hasher.update(patched.as_bytes());
         let hash = format!("{:x}", hasher.finalize());
 
-        format!(
-            "LOVELY_INTEGRITY = '{hash}'\n\n{patched}"
-        )
+        format!("LOVELY_INTEGRITY = '{hash}'\n\n{patched}")
     }
 }

--- a/crates/lovely-core/src/patch/copy.rs
+++ b/crates/lovely-core/src/patch/copy.rs
@@ -1,6 +1,6 @@
-use std::{fs, path::PathBuf};
 use crop::Rope;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -34,10 +34,10 @@ impl CopyPatch {
 
             // Append or prepend the patch's lines onto the provided buffer.
             match self.position {
-                CopyPosition::Prepend => { 
+                CopyPosition::Prepend => {
                     rope.insert(0, "\n");
                     rope.insert(0, &contents);
-                },
+                }
                 CopyPosition::Append => {
                     rope.insert(rope.byte_len(), "\n");
                     rope.insert(rope.byte_len(), &contents);

--- a/crates/lovely-core/src/patch/copy.rs
+++ b/crates/lovely-core/src/patch/copy.rs
@@ -35,8 +35,8 @@ impl CopyPatch {
             // Append or prepend the patch's lines onto the provided buffer.
             match self.position {
                 CopyPosition::Prepend => { 
-                    rope.insert(0,&contents);
-                    rope.insert(contents.len(), "\n");
+                    rope.insert(0, "\n");
+                    rope.insert(0, &contents);
                 },
                 CopyPosition::Append => {
                     rope.insert(rope.byte_len(), "\n");

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -86,10 +86,15 @@ impl PatternPatch {
             } else {
                 String::new()
             };
-            let mut payload = String::new();
-            if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
-                payload.push('\n');
-            }
+            let mut payload = if let InsertPosition::After = self.position {
+                if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
+                    String::from('\n')
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            };
             payload.push_str(
                 &self
                     .payload
@@ -97,8 +102,10 @@ impl PatternPatch {
                     .format_with("", |x, f| f(&format_args!("{}{}", indent, x)))
                     .to_string(),
             );
-            if !self.payload.ends_with('\n') {
-                payload.push('\n');
+            if let InsertPosition::Before = self.position {
+                if !self.payload.ends_with('\n') {
+                    payload.push('\n');
+                }
             }
 
             match self.position {

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -87,7 +87,7 @@ impl PatternPatch {
                 String::new()
             };
             let mut payload = String::new();
-            if !self.payload.starts_with('\n') {
+            if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
                 payload.push('\n');
             }
             payload.push_str(

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -72,9 +72,9 @@ impl PatternPatch {
                 String::new()
             };
 
-            let mut payload = self.payload.split('\n')
-                .map(|x| format!("{indent}{x}"))
-                .join("\n");
+            let mut payload = self.payload.split_inclusive('\n')
+                .format_with("", |x, f| f(&format_args!("{}{}", indent, x)))
+                .to_string();
             if !self.payload.ends_with('\n') {
                 payload.push('\n');
             }

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -77,7 +77,6 @@ impl PatternPatch {
         for (line_idx, line) in matches {
             let start = rope.byte_of_line(line_idx + line_delta);
             let end = start + line.len();
-            let payload_lines = self.payload.lines().count();
 
             let indent = if self.match_indent {
                 line.chars()
@@ -86,15 +85,12 @@ impl PatternPatch {
             } else {
                 String::new()
             };
-            let mut payload = if let InsertPosition::After = self.position {
+            let mut payload =
                 if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
                     String::from('\n')
                 } else {
                     String::new()
-                }
-            } else {
-                String::new()
-            };
+                };
             payload.push_str(
                 &self
                     .payload
@@ -102,11 +98,10 @@ impl PatternPatch {
                     .format_with("", |x, f| f(&format_args!("{}{}", indent, x)))
                     .to_string(),
             );
-            if let InsertPosition::Before = self.position {
-                if !self.payload.ends_with('\n') {
-                    payload.push('\n');
-                }
+            if !self.payload.ends_with('\n') {
+                payload.push('\n');
             }
+            let payload_lines = payload.lines().count();
 
             match self.position {
                 InsertPosition::Before => {

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -40,7 +40,7 @@ impl PatternPatch {
             .lines()
             .map(|x| x.trim())
             .map(WildMatch::new)
-            .collect::<Vec<_>>();
+            .collect_vec();
         if wm_lines.is_empty() {
             log::warn!("Pattern on target '{target}' has no lines");
             return false;
@@ -48,7 +48,7 @@ impl PatternPatch {
         let wm_lines_len = wm_lines.len();
 
         let mut line_index = 0usize;
-        let rope_lines = rope.raw_lines().map(|x| x.to_string()).collect::<Vec<_>>();
+        let rope_lines = rope.raw_lines().map(|x| x.to_string()).collect_vec();
         let mut matches = Vec::new();
         while let Option::Some(rope_window) = rope_lines.get(line_index..line_index + wm_lines_len)
         {
@@ -64,7 +64,7 @@ impl PatternPatch {
                             rope_window[0]
                                 .bytes()
                                 .take_while(|x| *x == b' ' || *x == b'\t')
-                                .collect::<Vec<_>>(),
+                                .collect_vec(),
                         )
                         .unwrap()
                     } else {

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -87,10 +87,8 @@ impl PatternPatch {
                 String::new()
             };
             let mut payload = String::new();
-            if let InsertPosition::After = self.position {
-                if !self.payload.starts_with('\n') {
-                    payload.push('\n');
-                }
+            if !self.payload.starts_with('\n') {
+                payload.push('\n');
             }
             payload.push_str(
                 &self
@@ -99,10 +97,8 @@ impl PatternPatch {
                     .format_with("", |x, f| f(&format_args!("{}{}", indent, x)))
                     .to_string(),
             );
-            if let InsertPosition::Before = self.position {
-                if !self.payload.ends_with('\n') {
-                    payload.push('\n');
-                }
+            if !self.payload.ends_with('\n') {
+                payload.push('\n');
             }
 
             match self.position {

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -57,20 +57,18 @@ impl PatternPatch {
                 .zip(wm_lines.iter())
                 .all(|(source, target)| target.matches(source.trim()))
             {
-                matches.push((
-                    line_index,
-                    if self.match_indent {
-                        String::from_utf8(
-                            rope_window[0]
-                                .bytes()
-                                .take_while(|x| *x == b' ' || *x == b'\t')
-                                .collect_vec(),
-                        )
-                        .unwrap()
-                    } else {
-                        String::new()
-                    },
-                ));
+                if self.match_indent {
+                    let leading_indent = String::from_utf8(
+                        rope_window[0]
+                            .bytes()
+                            .take_while(|x| *x == b' ' || *x == b'\t')
+                            .collect_vec(),
+                    )
+                    .unwrap();
+                    matches.push((line_index, leading_indent));
+                } else {
+                    matches.push((line_index, String::new()));
+                }
                 line_index += wm_lines.len();
             } else {
                 line_index += 1;

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -85,12 +85,7 @@ impl PatternPatch {
             } else {
                 String::new()
             };
-            let mut payload =
-                if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
-                    String::from('\n')
-                } else {
-                    String::new()
-                };
+            let mut payload = String::new();
             payload.push_str(
                 &self
                     .payload

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -34,14 +34,11 @@ impl PatternPatch {
         if self.target != target {
             return false;
         }
-        if self.target.is_empty() {
-            return false;
-        }
 
         let wm_lines = self
             .pattern
             .lines()
-            .map(|x| x.trim_end())
+            .map(|x| x.trim())
             .map(WildMatch::new)
             .collect::<Vec<_>>();
         if wm_lines.is_empty() {
@@ -69,9 +66,7 @@ impl PatternPatch {
                                 .take_while(|x| *x == b' ' || *x == b'\t')
                                 .collect::<Vec<_>>(),
                         )
-                        .expect(
-                            "String should consist of only \' \' and \'\\t\', which are both ASCII and therefore valid unicode",
-                        )
+                        .unwrap()
                     } else {
                         String::new()
                     },
@@ -91,20 +86,46 @@ impl PatternPatch {
         }
         if let Some(times) = self.times {
             if matches.len() < times {
-                log::warn!(
-                    "Pattern '{}' on target '{target}' resulted in {} matches, wanted {}",
-                    self.pattern.escape_debug(),
-                    matches.len(),
-                    times
-                );
+                if wm_lines_len > 1 {
+                    for line in format!(
+                        "Pattern '''\n{}''' on target '{target}' resulted in {} matches, wanted {}",
+                        self.pattern,
+                        matches.len(),
+                        times
+                    )
+                    .lines()
+                    {
+                        log::warn!("{}", line);
+                    }
+                } else {
+                    log::warn!(
+                        "Pattern '{}' on target '{target}' resulted in {} matches, wanted {}",
+                        self.pattern,
+                        matches.len(),
+                        times
+                    );
+                }
             }
             if matches.len() > times {
-                log::warn!(
-                    "Pattern '{}' on target '{target}' resulted in {} matches, wanted {}",
-                    self.pattern.escape_debug(),
-                    matches.len(),
-                    times
-                );
+                if wm_lines_len > 1 {
+                    for line in format!(
+                        "Pattern '''\n{}''' on target '{target}' resulted in {} matches, wanted {}",
+                        self.pattern,
+                        matches.len(),
+                        times
+                    )
+                    .lines()
+                    {
+                        log::warn!("{}", line);
+                    }
+                } else {
+                    log::warn!(
+                        "Pattern '{}' on target '{target}' resulted in {} matches, wanted {}",
+                        self.pattern,
+                        matches.len(),
+                        times
+                    );
+                }
                 log::warn!("Ignoring excess matches");
                 matches.truncate(times);
             }

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -1,5 +1,6 @@
 use regex_cursor::Input;
 use regex_cursor::engines::meta::Regex;
+use regex_cursor::regex_automata::util::syntax;
 use regex_cursor::regex_automata::util::interpolate;
 
 use itertools::Itertools;
@@ -43,7 +44,13 @@ impl RegexPatch {
         }
 
         let input = Input::new(rope.into_cursor());
-        let re = Regex::new(&self.pattern)
+        let re = Regex::builder()
+            .syntax(
+                 syntax::Config::new()
+                    .multi_line(true)
+                    .crlf(true)
+            )
+            .build(&self.pattern)
             .unwrap_or_else(|e| panic!("Failed to compile Regex '{}': {e:?}", self.pattern));
 
         let mut captures = re.captures_iter(input).collect_vec();

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -120,7 +120,7 @@ impl RegexPatch {
             // implementation seems to be broken when working with ropes.
             let mut payload = String::new();
             if let InsertPosition::After = self.position {
-                if !self.payload.starts_with('\n') {
+                if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
                     payload.push('\n');
                 }
             }

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -97,13 +97,9 @@ impl RegexPatch {
             // Prepend each line of the payload with line_prepend.
             let new_payload = self
                 .payload
-                .lines()
-                .map(|x| if !x.is_empty() {
-                    format!("{line_prepend}{x}")
-                } else {
-                    x.to_string()
-                })
-                .join("\n");
+                .split_inclusive('\n')
+                .format_with("", |x, f| f(&format_args!("{}{}", line_prepend, x)))
+                .to_string();
 
             // Interpolate capture groups into the payload.
             // We must use this method instead of Captures::interpolate_string because that

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -118,12 +118,15 @@ impl RegexPatch {
             // Interpolate capture groups into the payload.
             // We must use this method instead of Captures::interpolate_string because that
             // implementation seems to be broken when working with ropes.
-            let mut payload = String::new();
-            if let InsertPosition::After = self.position {
+            let mut payload = if let InsertPosition::After = self.position {
                 if !self.payload.starts_with('\n') && !self.payload.starts_with("\r\n") {
-                    payload.push('\n');
+                    String::from('\n')
+                } else {
+                    String::new()
                 }
-            }
+            } else {
+                String::new()
+            };
             interpolate::string(
                 &new_payload,
                 |index, dest| {

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -18,7 +18,7 @@ use super::InsertPosition;
 pub struct RegexPatch {
     pub target: String,
 
-    // The Regex pattern that will be used to both match and create capture groups.             
+    // The Regex pattern that will be used to both match and create capture groups.
     pub pattern: String,
 
     // The position to insert the payload relative to the match/capture group.
@@ -181,7 +181,7 @@ impl RegexPatch {
                 }
             }
 
-            // Interpolate capture groups into the payload. 
+            // Interpolate capture groups into the payload.
             // We must use this method instead of Captures::interpolate_string because that
             // implementation seems to be broken when working with ropes.
             let mut payload = String::new();

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -188,15 +188,12 @@ impl RegexPatch {
             }
 
             // Prepend each line of the payload with line_prepend.
-            std::fmt::write(
-                &mut new_payload, 
-                format_args!("{}", 
-                    self
-                        .payload
-                        .split_inclusive('\n')
-                        .format_with("", |x, f| f(&format_args!("{}{}", line_prepend, x)))
-                )
-            ).expect("std::fmt::write to str should not fail");
+            new_payload.push_str(&std::format!("{}", 
+                self
+                    .payload
+                    .split_inclusive('\n')
+                    .format_with("", |x, f| f(&format_args!("{}{}", line_prepend, x)))
+            ));
 
             // If right border of insertion is a non-wordchar -> wordchar 
             // boundary and our patch ends with a wordchar, append space so 

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -1,4 +1,6 @@
-use regex_cursor::regex_automata::meta::Config;
+use regex_cursor::regex_automata::util::lazy::Lazy;
+use regex_cursor::regex_automata::util::syntax::Config;
+use regex_cursor::regex_automata::Anchored;
 use regex_cursor::Input;
 use regex_cursor::engines::meta::Regex;
 use regex_cursor::regex_automata::util::syntax;
@@ -16,7 +18,7 @@ use super::InsertPosition;
 pub struct RegexPatch {
     pub target: String,
 
-    // The Regex pattern that will be used to both match and create capture groups.
+    // The Regex pattern that will be used to both match and create capture groups.             
     pub pattern: String,
 
     // The position to insert the payload relative to the match/capture group.
@@ -38,7 +40,7 @@ pub struct RegexPatch {
     // Apply patch at most `times` times, warn if the number of matches differs from `times`.
     pub times: Option<usize>,
 
-    // If enabled, whitespace is ignored unless escaped or in some constructs
+    // If enabled, whitespace is ignored unless escaped
     #[serde(default)]
     pub verbose: bool,
 }
@@ -62,15 +64,15 @@ impl RegexPatch {
 
         let mut captures = re.captures_iter(input).collect_vec();
         if captures.is_empty() {
-            log::warn!("Regex '{}' on target '{target}' resulted in no matches", self.pattern);
+            log::warn!("Regex '{}' on target '{target}' resulted in no matches", self.pattern.escape_debug());
             return false;
         }
         if let Some(times) = self.times {
             if captures.len() < times {
-                log::warn!("Regex '{}' on target '{target}' resulted in {} matches, wanted {}", self.pattern, captures.len(), times);
+                log::warn!("Regex '{}' on target '{target}' resulted in {} matches, wanted {}", self.pattern.escape_debug(), captures.len(), times);
             }
             if captures.len() > times {
-                log::warn!("Regex '{}' on target '{target}' resulted in {} matches, wanted {}", self.pattern, captures.len(), times);
+                log::warn!("Regex '{}' on target '{target}' resulted in {} matches, wanted {}", self.pattern.escape_debug(), captures.len(), times);
                 log::warn!("Ignoring excess matches");
                 captures.truncate(times);
             }
@@ -108,42 +110,6 @@ impl RegexPatch {
                 &mut line_prepend
             );
 
-            // Prepend each line of the payload with line_prepend.
-            let mut new_payload = self
-                .payload
-                .split_inclusive('\n')
-                .format_with("", |x, f| f(&format_args!("{}{}", line_prepend, x)))
-                .to_string();
-
-            match self.position {
-                InsertPosition::At => (),
-                _ => if !self.payload.ends_with('\n')  {
-                    new_payload.push('\n');
-                }
-            }
-
-            // Interpolate capture groups into the payload.
-            // We must use this method instead of Captures::interpolate_string because that
-            // implementation seems to be broken when working with ropes.
-            let mut payload = String::new();
-            interpolate::string(
-                &new_payload,
-                |index, dest| {
-                    let span = groups.get_group(index).unwrap();
-                    let start = (span.start as isize + delta) as usize;
-                    let end = (span.end as isize + delta) as usize;
-
-                    let rope_slice = rope.byte_slice(start..end);
-
-                    dest.push_str(&rope_slice.to_string());
-                },
-                |name| {
-                    let pid = groups.pattern().unwrap();
-                    groups.group_info().to_index(pid, name)
-                },
-                &mut payload
-            );
-
             // Cleanup and convert the specified root capture to a span.
             let target_group = {
                 let group_name = self
@@ -165,6 +131,78 @@ impl RegexPatch {
 
             let target_start = (target_group.start as isize + delta) as usize;
             let target_end = (target_group.end as isize + delta) as usize;
+
+            let mut new_payload = String::new();
+
+            // If left border of insertion is a wordchar -> non-wordchar 
+            // boundary and our patch starts with a wordchar, prepend space so 
+            // it doesn't unintentionally concatenate with characters to its 
+            // left to create a larger identifier.
+            if self.payload.starts_with(|x: char| x.is_ascii_alphanumeric() || x == '_' || x == '$' || x == '{' || x == '}') {
+                let pre_pt = if let InsertPosition::After = self.position {
+                    target_end
+                } else {
+                    target_start
+                };
+                if pre_pt > 0 {
+                    let byte_on_left = rope.byte(pre_pt - 1);
+                    if byte_on_left.is_ascii_alphanumeric() || byte_on_left == b'_' {
+                        new_payload.push(' ');
+                    }
+                }
+            }
+
+            // Prepend each line of the payload with line_prepend.
+            std::fmt::write(
+                &mut new_payload, 
+                format_args!("{}", 
+                    self
+                        .payload
+                        .split_inclusive('\n')
+                        .format_with("", |x, f| f(&format_args!("{}{}", line_prepend, x)))
+                )
+            ).expect("std::fmt::write to str should not fail");
+
+            // If right border of insertion is a non-wordchar -> wordchar 
+            // boundary and our patch ends with a wordchar, append space so 
+            // it doesn't unintentionally concatenate with characters to its 
+            // right to create a larger identifier.     
+            if self.payload.ends_with(|x: char| x.is_ascii_alphanumeric() || x == '_' || x == '$' || x == '{' || x == '}') {
+                let post_pt = if let InsertPosition::Before = self.position {
+                    target_start
+                } else {
+                    target_end
+                };
+                if post_pt < rope.byte_len() {
+                    let byte_on_right = rope.byte(post_pt);
+                    if byte_on_right.is_ascii_alphanumeric() || byte_on_right == b'_' {
+                        new_payload.push(' ');
+                    }
+                }
+            }
+
+            // Interpolate capture groups into the payload. 
+            // We must use this method instead of Captures::interpolate_string because that
+            // implementation seems to be broken when working with ropes.
+            let mut payload = String::new();
+
+            interpolate::string(
+                &new_payload,
+                |index, dest| {
+                    let span = groups.get_group(index).unwrap();
+                    let start = (span.start as isize + delta) as usize;
+                    let end = (span.end as isize + delta) as usize;
+
+                    let rope_slice = rope.byte_slice(start..end);
+
+                    dest.push_str(&rope_slice.to_string());
+                },
+                |name| {
+                    let pid = groups.pattern().unwrap();
+                    groups.group_info().to_index(pid, name)
+                },
+                &mut payload
+            );
 
             match self.position {
                 InsertPosition::Before => {

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -1,4 +1,7 @@
-use std::{ffi::{c_void, CString}, slice};
+use std::{
+    ffi::{c_void, CString},
+    slice,
+};
 
 use libc::FILE;
 use libloading::{Library, Symbol};
@@ -12,110 +15,68 @@ pub const LUA_TBOOLEAN: isize = 1;
 
 pub type LuaState = c_void;
 
-
 #[cfg(target_os = "windows")]
-pub static LUA_LIB: Lazy<Library> = Lazy::new(|| {
-    unsafe {
-        Library::new("lua51.dll").unwrap()
-    }
-});
+pub static LUA_LIB: Lazy<Library> = Lazy::new(|| unsafe { Library::new("lua51.dll").unwrap() });
 
 #[cfg(target_os = "macos")]
-pub static LUA_LIB: Lazy<Library> = Lazy::new(|| {
-    unsafe {
-        Library::new("../Frameworks/Lua.framework/Versions/A/Lua").unwrap()
-    }
-});
+pub static LUA_LIB: Lazy<Library> =
+    Lazy::new(|| unsafe { Library::new("../Frameworks/Lua.framework/Versions/A/Lua").unwrap() });
 
+pub static lua_call: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, isize)>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_call").unwrap() });
 
-pub static lua_call: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, isize)>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_call").unwrap()
-    }
-});
+pub static lua_pcall: Lazy<
+    Symbol<unsafe extern "C" fn(*mut LuaState, isize, isize, isize) -> isize>,
+> = Lazy::new(|| unsafe { LUA_LIB.get(b"lua_pcall").unwrap() });
 
-pub static lua_pcall: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, isize, isize) -> isize>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_pcall").unwrap()
-    }
-});
+pub static lua_getfield: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, *const char)>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_getfield").unwrap() });
 
-pub static lua_getfield: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, *const char)>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_getfield").unwrap()
-    }
-});
+pub static lua_setfield: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, *const char)>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_setfield").unwrap() });
 
-pub static lua_setfield: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, *const char)>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_setfield").unwrap()
-    }
-});
+pub static lua_gettop: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState) -> isize>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_gettop").unwrap() });
 
-pub static lua_gettop: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState) -> isize>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_gettop").unwrap()
-    }
-});
+pub static lua_settop: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> isize>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_settop").unwrap() });
 
-pub static lua_settop: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> isize>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_settop").unwrap()
-    }
-});
+pub static lua_pushvalue: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize)>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_pushvalue").unwrap() });
 
-pub static lua_pushvalue: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize)>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_pushvalue").unwrap()
-    }
-});
+pub static lua_pushcclosure: Lazy<
+    Symbol<unsafe extern "C" fn(*mut LuaState, *const c_void, isize)>,
+> = Lazy::new(|| unsafe { LUA_LIB.get(b"lua_pushcclosure").unwrap() });
 
-pub static lua_pushcclosure: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, *const c_void, isize)>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_pushcclosure").unwrap()
-    }
-});
+pub static lua_tolstring: Lazy<
+    Symbol<unsafe extern "C" fn(*mut LuaState, isize, *mut isize) -> *const char>,
+> = Lazy::new(|| unsafe { LUA_LIB.get(b"lua_tolstring").unwrap() });
 
-pub static lua_tolstring: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize, *mut isize) -> *const char>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_tolstring").unwrap()
-    }
-});
+pub static lua_toboolean: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> bool>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_toboolean").unwrap() });
 
-pub static lua_toboolean: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> bool>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_toboolean").unwrap()
-    }
-});
+pub static lua_topointer: Lazy<
+    Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> *const c_void>,
+> = Lazy::new(|| unsafe { LUA_LIB.get(b"lua_topointer").unwrap() });
 
-pub static lua_topointer: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> *const c_void>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_topointer").unwrap()
-    }
-});
+pub static lua_type: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> isize>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_type").unwrap() });
 
-pub static lua_type: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> isize>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_type").unwrap()
-    }
-});
+pub static lua_typename: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> *const char>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_typename").unwrap() });
 
-pub static lua_typename: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> *const char>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_typename").unwrap()
-    }
-});
-
-pub static lua_isstring: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> isize>> = Lazy::new(|| {
-    unsafe {
-        LUA_LIB.get(b"lua_isstring").unwrap()
-    }
-});
+pub static lua_isstring: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) -> isize>> =
+    Lazy::new(|| unsafe { LUA_LIB.get(b"lua_isstring").unwrap() });
 
 /// Load the provided buffer as a lua module with the specified name.
 /// # Safety
 /// Makes a lot of FFI calls, mutates internal C lua state.
-pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8) -> u32>(state: *mut LuaState, name: &str, buffer: &str, lual_loadbuffer: &F) {
+pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8) -> u32>(
+    state: *mut LuaState,
+    name: &str,
+    buffer: &str,
+    lual_loadbuffer: &F,
+) {
     let buf_cstr = CString::new(buffer).unwrap();
     let buf_len = buf_cstr.as_bytes().len();
 
@@ -131,7 +92,12 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8) -> u
     let field_index = lua_gettop(state);
 
     // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-    lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, p_name_cstr.into_raw() as _);
+    lual_loadbuffer(
+        state,
+        buf_cstr.into_raw() as _,
+        buf_len as _,
+        p_name_cstr.into_raw() as _,
+    );
 
     lua_pcall(state, 0, -1, 0);
 
@@ -150,13 +116,13 @@ pub unsafe extern "C" fn override_print(state: *mut LuaState) -> isize {
     let mut out = String::new();
 
     for i in 0..argc {
-        let mut str_len = 0_isize; 
+        let mut str_len = 0_isize;
         let arg_str = lua_tolstring(state, -1, &mut str_len);
         if arg_str.is_null() {
             out.push_str("[G] nil");
             continue;
         }
-        
+
         let str_buf = slice::from_raw_parts(arg_str as *const u8, str_len as _);
         let arg_str = String::from_utf8_lossy(str_buf);
 

--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -47,8 +47,8 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
         );
     }));
 
-    let args = env::args().collect_vec();
-    if !args.contains(&"--disable-console".to_string()) {
+    let args = env::args().collect::<Vec<_>>();
+    if !args.contains(&"--disable-console".to_string()) { 
         let _ = AllocConsole();
     }
 

--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -1,12 +1,11 @@
 use std::env;
-use std::panic;
 use std::ffi::c_void;
+use std::panic;
 
 use lovely_core::log::*;
-use lovely_core::Lovely;
 use lovely_core::sys::LuaState;
+use lovely_core::Lovely;
 
-use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use retour::static_detour;
 use widestring::U16CString;
@@ -22,7 +21,12 @@ static_detour! {
     pub static LuaLoadbuffer_Detour: unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8) -> u32;
 }
 
-unsafe extern "C" fn lua_loadbuffer_detour(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8) -> u32 {
+unsafe extern "C" fn lua_loadbuffer_detour(
+    state: *mut LuaState,
+    buf_ptr: *const u8,
+    size: isize,
+    name_ptr: *const u8,
+) -> u32 {
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr)
 }
@@ -48,26 +52,29 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
     }));
 
     let args = env::args().collect::<Vec<_>>();
-    if !args.contains(&"--disable-console".to_string()) { 
+    if !args.contains(&"--disable-console".to_string()) {
         let _ = AllocConsole();
     }
 
     // Initialize the lovely runtime.
     let rt = Lovely::init(&|a, b, c, d| LuaLoadbuffer_Detour.call(a, b, c, d));
-    RUNTIME.set(rt).unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+    RUNTIME
+        .set(rt)
+        .unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
 
     // Quick and easy hook injection. Load the lua51.dll module at runtime, determine the address of the luaL_loadbuffer fn, hook it.
     let handle = LoadLibraryW(w!("lua51.dll")).unwrap();
     let proc = GetProcAddress(handle, s!("luaL_loadbuffer")).unwrap();
-    let fn_target = std::mem::transmute::<_, unsafe extern "C" fn(*mut c_void, *const u8, isize, *const u8) -> u32>(proc);
+    let fn_target = std::mem::transmute::<
+        _,
+        unsafe extern "C" fn(*mut c_void, *const u8, isize, *const u8) -> u32,
+    >(proc);
 
-    LuaLoadbuffer_Detour.initialize(
-        fn_target,
-        |a, b, c, d| lua_loadbuffer_detour(a, b, c, d)
-    )
-    .unwrap()
-    .enable()
-    .unwrap();
+    LuaLoadbuffer_Detour
+        .initialize(fn_target, |a, b, c, d| lua_loadbuffer_detour(a, b, c, d))
+        .unwrap()
+        .enable()
+        .unwrap();
 
     1
 }

--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::ffi::c_void;
 use std::panic;
 
+use itertools::Itertools;
 use lovely_core::log::*;
 use lovely_core::sys::LuaState;
 use lovely_core::Lovely;
@@ -51,7 +52,7 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
         );
     }));
 
-    let args = env::args().collect::<Vec<_>>();
+    let args = env::args().collect_vec();
     if !args.contains(&"--disable-console".to_string()) {
         let _ = AllocConsole();
     }


### PR DESCRIPTION
* As suggested in  #52 , use split_inclusive and raw_lines consistently. 
* Add some flags to regex patches so they are multi-line, and smartly pad insertions to avoid accidentally concatenating to identifiers (they can still be intentionally concatenated to using explicit capturing of the identifier)
* Implement multi-line pattern patches