### PR TITLE
Allow patching games running on LOVE2D 12, or otherwise using luaL_loadbufferx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,6 @@ version = "0.1.0"
 dependencies = [
  "ctor",
  "libc",
- "log",
  "lovely-core",
  "once_cell",
 ]
@@ -418,7 +417,6 @@ dependencies = [
  "forward-dll",
  "itertools",
  "libc",
- "log",
  "lovely-core",
  "once_cell",
  "retour",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "forward-dll",
  "itertools",
  "libc",
+ "log",
  "lovely-core",
  "once_cell",
  "retour",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ version = "0.1.0"
 dependencies = [
  "ctor",
  "libc",
+ "log",
  "lovely-core",
  "once_cell",
 ]

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -23,7 +23,7 @@ pub mod sys;
 pub mod log;
 pub mod patch;
 
-type LoadBuffer = dyn Fn(*mut LuaState, *const u8, isize, *const u8) -> u32 + Send + Sync + 'static;
+type LoadBuffer = dyn Fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32 + Send + Sync + 'static;
 
 pub struct Lovely {
     pub mod_dir: PathBuf,
@@ -142,7 +142,7 @@ impl Lovely {
     /// This function is unsafe because
     /// - It interacts and manipulates memory directly through native pointers
     /// - It interacts, calls, and mutates native lua state through native pointers
-    pub unsafe fn apply_buffer_patches(&self, state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8) -> u32 {
+    pub unsafe fn apply_buffer_patches(&self, state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8, mode_ptr: *const u8) -> u32 {
         // Install native function overrides.
         self.rt_init.call_once(|| {
             let closure = sys::override_print as *const c_void;
@@ -158,7 +158,7 @@ impl Lovely {
 
         // Stop here if no valid patch exists for this target.
         if !self.patch_table.needs_patching(name) {
-            return (self.loadbuffer)(state, buf_ptr, size, name_ptr);
+            return (self.loadbuffer)(state, buf_ptr, size, name_ptr, mode_ptr);
         }
 
         // Prepare buffer for patching (Check and remove the last byte if it is a null terminator)
@@ -193,7 +193,7 @@ impl Lovely {
         let raw_size = raw.as_bytes().len();
         let raw_ptr = raw.into_raw();
 
-        (self.loadbuffer)(state, raw_ptr as _, raw_size as _, name_ptr)
+        (self.loadbuffer)(state, raw_ptr as _, raw_size as _, name_ptr, mode_ptr)
     }
 }
 

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -1,5 +1,4 @@
-use std::{ffi::CString, fs, path::PathBuf};
-use std::ptr::null;
+use std::{ffi::CString, fs, path::PathBuf, ptr};
 use crate::sys::{self, LuaState};
 use serde::{Serialize, Deserialize};
 
@@ -48,7 +47,7 @@ impl ModulePatch {
         let field_index = sys::lua_gettop(state);
 
         // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-        lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, name_cstr.into_raw() as _, null());
+        lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, name_cstr.into_raw() as _, ptr::null());
 
         sys::lua_pcall(state, 0, -1, 0);
 

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -1,5 +1,5 @@
 use std::{ffi::CString, fs, path::PathBuf};
-
+use std::ptr::null;
 use crate::sys::{self, LuaState};
 use serde::{Serialize, Deserialize};
 
@@ -17,7 +17,7 @@ impl ModulePatch {
     /// # Safety
     /// This function is unsafe as it interfaces directly with a series of dynamically loaded
     /// native lua functions.
-    pub unsafe fn apply<F: Fn(*mut LuaState, *const u8, isize, *const u8) -> u32>(
+    pub unsafe fn apply<F: Fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(
         &self, 
         file_name: &str, 
         state: *mut LuaState, 
@@ -48,7 +48,7 @@ impl ModulePatch {
         let field_index = sys::lua_gettop(state);
 
         // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-        lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, name_cstr.into_raw() as _);
+        lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, name_cstr.into_raw() as _, null());
 
         sys::lua_pcall(state, 0, -1, 0);
 

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -1,5 +1,5 @@
 use std::{ffi::{c_void, CString}, slice};
-
+use std::ptr::null;
 use libc::FILE;
 use libloading::{Library, Symbol};
 use log::info;
@@ -115,7 +115,7 @@ pub static lua_isstring: Lazy<Symbol<unsafe extern "C" fn(*mut LuaState, isize) 
 /// Load the provided buffer as a lua module with the specified name.
 /// # Safety
 /// Makes a lot of FFI calls, mutates internal C lua state.
-pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8) -> u32>(state: *mut LuaState, name: &str, buffer: &str, lual_loadbuffer: &F) {
+pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(state: *mut LuaState, name: &str, buffer: &str, lual_loadbuffer: &F) {
     let buf_cstr = CString::new(buffer).unwrap();
     let buf_len = buf_cstr.as_bytes().len();
 
@@ -131,7 +131,7 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8) -> u
     let field_index = lua_gettop(state);
 
     // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-    lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, p_name_cstr.into_raw() as _);
+    lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, p_name_cstr.into_raw() as _, null());
 
     lua_pcall(state, 0, -1, 0);
 

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -1,5 +1,4 @@
-use std::{ffi::{c_void, CString}, slice};
-use std::ptr::null;
+use std::{ffi::{c_void, CString}, ptr, slice};
 use libc::FILE;
 use libloading::{Library, Symbol};
 use log::info;
@@ -131,7 +130,7 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *con
     let field_index = lua_gettop(state);
 
     // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-    lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, p_name_cstr.into_raw() as _, null());
+    lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, p_name_cstr.into_raw() as _, ptr::null());
 
     lua_pcall(state, 0, -1, 0);
 

--- a/crates/lovely-mac/Cargo.toml
+++ b/crates/lovely-mac/Cargo.toml
@@ -13,3 +13,4 @@ lovely-core = { version ="0.5.0-beta7", path = "../lovely-core" }
 libc = "0.2.153"
 once_cell = "1.19.0"
 ctor = "0.2.7"
+log = "0.4.21"

--- a/crates/lovely-mac/Cargo.toml
+++ b/crates/lovely-mac/Cargo.toml
@@ -13,4 +13,4 @@ lovely-core = { version ="0.5.0-beta7", path = "../lovely-core" }
 libc = "0.2.153"
 once_cell = "1.19.0"
 ctor = "0.2.7"
-log = "0.4.21"
+

--- a/crates/lovely-mac/src/lib.rs
+++ b/crates/lovely-mac/src/lib.rs
@@ -3,7 +3,7 @@ use lovely_core::sys::LuaState;
 
 use lovely_core::Lovely;
 use once_cell::sync::{Lazy, OnceCell};
-use log::info;
+
 
 static RUNTIME: OnceCell<Lovely> = OnceCell::new();
 

--- a/crates/lovely-mac/src/lib.rs
+++ b/crates/lovely-mac/src/lib.rs
@@ -18,8 +18,7 @@ static RECALL: Lazy<unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const
     if ptr.is_null() {
         panic!("Failed to load luaL_loadbufferx");
     }
-
-    info!("Loaded luaL_loadbufferx");
+    
     std::mem::transmute::<_, unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(ptr)
     
 });
@@ -27,7 +26,6 @@ static RECALL: Lazy<unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const
 #[no_mangle]
 #[allow(non_snake_case)]
 unsafe extern "C" fn luaL_loadbuffer(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8) -> u32 {
-    info!("Calling luaL_loadbuffer");
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, null())
 }
@@ -36,7 +34,6 @@ unsafe extern "C" fn luaL_loadbuffer(state: *mut LuaState, buf_ptr: *const u8, s
 #[no_mangle]
 #[allow(non_snake_case)]
 unsafe extern "C" fn luaL_loadbufferx(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8, mode_ptr: *const u8) -> u32 {
-    info!("Calling luaL_loadbuffer");
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, mode_ptr)
 }

--- a/crates/lovely-mac/src/lib.rs
+++ b/crates/lovely-mac/src/lib.rs
@@ -30,7 +30,7 @@ unsafe extern "C" fn luaL_loadbuffer(state: *mut LuaState, buf_ptr: *const u8, s
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, null())
 }
 
-// we can do this on mac because nothing matters in this world except my pain
+
 #[no_mangle]
 #[allow(non_snake_case)]
 unsafe extern "C" fn luaL_loadbufferx(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8, mode_ptr: *const u8) -> u32 {

--- a/crates/lovely-mac/src/lib.rs
+++ b/crates/lovely-mac/src/lib.rs
@@ -5,29 +5,29 @@ use once_cell::sync::{Lazy, OnceCell};
 
 static RUNTIME: OnceCell<Lovely> = OnceCell::new();
 
-static RECALL: Lazy<unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8) -> u32> = Lazy::new(|| unsafe {
+static RECALL: Lazy<unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32> = Lazy::new(|| unsafe {
     let handle = libc::dlopen(b"../Frameworks/Lua.framework/Versions/A/Lua\0".as_ptr() as _, libc::RTLD_LAZY);
     
     if handle.is_null() {
         panic!("Failed to load lua");
     }
-    let ptr = libc::dlsym(handle, b"luaL_loadbuffer\0".as_ptr() as _);
+    let ptr = libc::dlsym(handle, b"luaL_loadbufferx\0".as_ptr() as _);
     
     if ptr.is_null() {
-        panic!("Failed to load luaL_loadbuffer");
+        panic!("Failed to load luaL_loadbufferx");
     }
-    std::mem::transmute::<_, unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8) -> u32>(ptr)
+    std::mem::transmute::<_, unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(ptr)
     
 });
 
 #[no_mangle]
-unsafe extern "C" fn luaL_loadbuffer(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8) -> u32 {
+unsafe extern "C" fn luaL_loadbufferx(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8, mode_ptr: *const u8) -> u32 {
     let rt = RUNTIME.get_unchecked();
-    rt.apply_buffer_patches(state, buf_ptr, size, name_ptr)
+    rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, mode_ptr)
 }
 
 #[ctor::ctor]
 unsafe fn construct() {
-    let rt = Lovely::init(&|a, b, c, d| RECALL(a, b, c, d));
+    let rt = Lovely::init(&|a, b, c, d,e| RECALL(a, b, c, d,e));
     RUNTIME.set(rt).unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
 }

--- a/crates/lovely-win/Cargo.toml
+++ b/crates/lovely-win/Cargo.toml
@@ -14,7 +14,7 @@ itertools = "0.13.0"
 libc = "0.2.141"
 once_cell = "1.19.0"
 widestring = "1.0.2"
-log = "0.4.21"
+
 
 [dependencies.retour]
 git = "https://github.com/Hpmason/retour-rs.git"

--- a/crates/lovely-win/Cargo.toml
+++ b/crates/lovely-win/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.13.0"
 libc = "0.2.141"
 once_cell = "1.19.0"
 widestring = "1.0.2"
+log = "0.4.21"
 
 [dependencies.retour]
 git = "https://github.com/Hpmason/retour-rs.git"

--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -65,9 +65,9 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
         fn_target,
         |a, b, c, d,e| lua_loadbufferx_detour(a, b, c, d,e)
     )
-        .unwrap()
-        .enable()
-        .unwrap();
+    .unwrap()
+    .enable()
+    .unwrap();
 
     1
 }


### PR DESCRIPTION
I have a whole 5 hours saga behind this. Generally, the entire system has been ported to use luaL_loadbufferx instead of luaL_loadbuffer. on the Balatro side, this should change nothing. the game already used it internally.  Games on newer versions of love like love 12 should now work properly. tested with no issues on Mac and Windows, with both Balatro (Love 11.5) and the Beatblock demo(Love 12.0)