### PR TITLE
Load modules lazily through package.preload

### DIFF
--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -1,6 +1,7 @@
-use std::{ffi::CString, fs, path::PathBuf, ptr};
+use std::{ffi::CString, fs, path::PathBuf, ptr, slice};
+
 use crate::sys::{self, LuaState};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ModulePatch {
@@ -11,15 +12,15 @@ pub struct ModulePatch {
 
 impl ModulePatch {
     /// Apply a module patch by loading the input file(s) into memory, calling lual_loadbuffer
-    /// on them, and then injecting them into the global `package.loaded` table.
-    /// 
+    /// on them, and then injecting them into the global `package.preload` table.
+    ///
     /// # Safety
     /// This function is unsafe as it interfaces directly with a series of dynamically loaded
     /// native lua functions.
     pub unsafe fn apply<F: Fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(
-        &self, 
-        file_name: &str, 
-        state: *mut LuaState, 
+        &self,
+        file_name: &str,
+        state: *mut LuaState,
         lual_loadbuffer: &F,
     ) -> bool {
         // Stop if we're not at the correct insertion point.
@@ -31,32 +32,59 @@ impl ModulePatch {
         let source = fs::read_to_string(&self.source)
             .unwrap_or_else(|e| panic!("Failed to read patch file at {:?}: {e:?}", &self.source));
 
-
         let buf_cstr = CString::new(source.as_str()).unwrap();
         let buf_len = buf_cstr.as_bytes().len();
 
         let name = format!("@{file_name}");
         let name_cstr = CString::new(name).unwrap();
 
-        // Push the global package.loaded table onto the top of the stack, saving its index.
+        // Push the global package.preload table onto the top of the stack, saving its index.
         let stack_top = sys::lua_gettop(state);
         sys::lua_getfield(state, sys::LUA_GLOBALSINDEX, b"package\0".as_ptr() as _);
-        sys::lua_getfield(state, -1, b"loaded\0".as_ptr() as _);
+        sys::lua_getfield(state, -1, b"preload\0".as_ptr() as _);
 
-        // This is the index of the `package.loaded` table.
+        // This is the index of the `package.preload` table.
         let field_index = sys::lua_gettop(state);
 
         // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-        lual_loadbuffer(state, buf_cstr.into_raw() as _, buf_len as _, name_cstr.into_raw() as _, ptr::null());
+        lual_loadbuffer(
+            state,
+            buf_cstr.into_raw() as _,
+            buf_len as _,
+            name_cstr.into_raw() as _,
+            ptr::null(),
+        );
 
-        sys::lua_pcall(state, 0, -1, 0);
+        let return_code = sys::lua_pcall(state, 0, -1, 0);
 
-        // Insert pcall results onto the package.loaded global table.
-        let module_cstr = CString::new(self.name.clone()).unwrap();
+        if return_code == 0 {
+            // Call succeeded, insert results onto the package.preload global table.
+            let module_cstr = CString::new(self.name.clone()).unwrap();
 
-        sys::lua_setfield(state, field_index, module_cstr.into_raw() as _);
-        sys::lua_settop(state, stack_top);
+            sys::lua_setfield(state, field_index, module_cstr.into_raw() as _);
+            sys::lua_settop(state, stack_top);
 
-        true
+            true
+        } else {
+            // We might quietly convert a number to a string, but this is fine,
+            // as we're just printing it as a diagnostic, and popping it off
+            // immediately afterwards
+            let mut error_cstr_len = 0;
+            let error_cstr = sys::lua_tolstring(state, field_index, &mut error_cstr_len);
+            if !error_cstr.is_null() {
+                log::error!(
+                    "Loading module {} failed with error {}",
+                    self.name,
+                    String::from_utf8_lossy(slice::from_raw_parts(
+                        error_cstr as *const u8,
+                        error_cstr_len.try_into().unwrap()
+                    ))
+                );
+            } else {
+                log::error!("Loading module {} failed with unknown error", self.name);
+            }
+            sys::lua_settop(state, stack_top);
+            false
+        }
     }
 }

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -1,6 +1,11 @@
-use std::{ffi::CString, fs, path::PathBuf, ptr, slice};
+use std::{
+    ffi::{c_void, CString},
+    fs,
+    path::PathBuf,
+    ptr, slice,
+};
 
-use crate::sys::{self, LuaState};
+use crate::sys::{self, lua_identity_closure, LuaState};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -74,7 +79,7 @@ impl ModulePatch {
                 return false;
             }
             // Wrap this in the identity closure function
-            sys::lua_pushcclosure(state, sys::lua_identity_closure as *const c_void, 1);
+            sys::lua_pushcclosure(state, lua_identity_closure as *const c_void, 1);
         }
 
         // Insert results onto the package.preload global table.

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -20,7 +20,7 @@ pub struct ModulePatch {
 }
 
 impl ModulePatch {
-    /// Apply a module patch by loading the input file(s) into memory, calling lual_loadbuffer
+    /// Apply a module patch by loading the input file(s) into memory, calling lual_loadbufferx
     /// on them, and then injecting them into the global `package.preload` table.
     ///
     /// # Safety
@@ -30,7 +30,7 @@ impl ModulePatch {
         &self,
         file_name: &str,
         state: *mut LuaState,
-        lual_loadbuffer: &F,
+        lual_loadbufferx: &F,
     ) -> bool {
         // Stop if we're not at the correct insertion point.
         if self.before != file_name {
@@ -56,7 +56,7 @@ impl ModulePatch {
         let field_index = sys::lua_gettop(state);
 
         // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-        let return_code = lual_loadbuffer(
+        let return_code = lual_loadbufferx(
             state,
             buf_cstr.into_raw() as _,
             buf_len as _,

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -139,14 +139,12 @@ impl RegexPatch {
             let target_start = (target_group.start as isize + delta) as usize;
             let target_end = (target_group.end as isize + delta) as usize;
 
-            let mut new_payload = std::format!("{}", 
+            let new_payload = std::format!("{}", 
                 self
                     .payload
                     .split_inclusive('\n')
                     .format_with("", |x, f| f(&format_args!("{}{}", line_prepend, x)))
             );
-
-
 
             // Interpolate capture groups into the payload.
             // We must use this method instead of Captures::interpolate_string because that

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -1,4 +1,7 @@
-use std::{ffi::{c_void, CString}, ptr, slice};
+use std::{
+    ffi::{c_void, CString},
+    ptr, slice,
+};
 
 use libc::FILE;
 use libloading::{Library, Symbol};
@@ -72,7 +75,7 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *con
     state: *mut LuaState,
     name: &str,
     buffer: &str,
-    lual_loadbuffer: &F
+    lual_loadbufferx: &F,
 ) {
     let buf_cstr = CString::new(buffer).unwrap();
     let buf_len = buf_cstr.as_bytes().len();
@@ -89,12 +92,12 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *con
     let field_index = lua_gettop(state);
 
     // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
-    lual_loadbuffer(
+    lual_loadbufferx(
         state,
         buf_cstr.into_raw() as _,
         buf_len as _,
         p_name_cstr.into_raw() as _,
-        ptr::null()
+        ptr::null(),
     );
 
     let lua_pcall_return = lua_pcall(state, 0, -1, 0);

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -99,7 +99,7 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *con
 
     let lua_pcall_return = lua_pcall(state, 0, -1, 0);
     if lua_pcall_return == 0 {
-        sys::lua_pushcclosure(state, lua_identity_closure as *const c_void, 1);
+        lua_pushcclosure(state, lua_identity_closure as *const c_void, 1);
         // Insert wrapped pcall results onto the package.preload global table.
         let module_cstr = CString::new(name).unwrap();
 

--- a/crates/lovely-mac/src/lib.rs
+++ b/crates/lovely-mac/src/lib.rs
@@ -1,47 +1,44 @@
+use lovely_core::sys::{LuaState, LUA_LIB};
 use std::ptr::null;
-use lovely_core::sys::LuaState;
 
 use lovely_core::Lovely;
 use once_cell::sync::{Lazy, OnceCell};
 
-
 static RUNTIME: OnceCell<Lovely> = OnceCell::new();
 
-static RECALL: Lazy<unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32> = Lazy::new(|| unsafe {
-    let handle = libc::dlopen(b"../Frameworks/Lua.framework/Versions/A/Lua\0".as_ptr() as _, libc::RTLD_LAZY);
-    
-    if handle.is_null() {
-        panic!("Failed to load lua");
-    }
-    let ptr = libc::dlsym(handle, b"luaL_loadbufferx\0".as_ptr() as _);
-    
-    if ptr.is_null() {
-        panic!("Failed to load luaL_loadbufferx");
-    }
-    
-    std::mem::transmute::<_, unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(ptr)
-    
-});
+static RECALL: Lazy<
+    unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32,
+> = Lazy::new(|| unsafe { *LUA_LIB.get(b"luaL_loadbufferx").unwrap() });
 
 #[no_mangle]
 #[allow(non_snake_case)]
-unsafe extern "C" fn luaL_loadbuffer(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8) -> u32 {
+unsafe extern "C" fn luaL_loadbuffer(
+    state: *mut LuaState,
+    buf_ptr: *const u8,
+    size: isize,
+    name_ptr: *const u8,
+) -> u32 {
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, null())
 }
 
-
 #[no_mangle]
 #[allow(non_snake_case)]
-unsafe extern "C" fn luaL_loadbufferx(state: *mut LuaState, buf_ptr: *const u8, size: isize, name_ptr: *const u8, mode_ptr: *const u8) -> u32 {
+unsafe extern "C" fn luaL_loadbufferx(
+    state: *mut LuaState,
+    buf_ptr: *const u8,
+    size: isize,
+    name_ptr: *const u8,
+    mode_ptr: *const u8,
+) -> u32 {
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, mode_ptr)
 }
 
-
 #[ctor::ctor]
 unsafe fn construct() {
-
-    let rt = Lovely::init(&|a, b, c, d,e| RECALL(a, b, c, d,e));
-    RUNTIME.set(rt).unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+    let rt = Lovely::init(&|a, b, c, d, e| RECALL(a, b, c, d, e));
+    RUNTIME
+        .set(rt)
+        .unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
 }


### PR DESCRIPTION
Change the module loading system to use `package.preload` for loading packages, which uses Lua's intended mechanisms for loading modules into Lua from C, rather than through `package.loaded` which is Lua's module cache. This change also loads modules lazily. As an escape hatch for potential unintentional dependency on lovely's previous eager module loading order, module patches have an additional option `load_now`, which if enabled loads them eagerly rather than lazily. 