### PR TITLE
fix: module source names

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -314,6 +314,7 @@ impl PatchTable {
                         targets.insert(x.target.clone());
                     }
                     Patch::Module(ref mut x) => {
+                        x.display_source = x.source.clone().into_os_string().into_string().unwrap_or_default();
                         x.source = mod_dir.join(&x.source);
                         targets.insert(x.before.clone());
                     }

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -17,6 +17,7 @@ pub struct ModulePatch {
     // If enabled, evaluate the module immediately upon loading it
     #[serde(default)]
     pub load_now: bool,
+    // Used for the display name of the source. Is the relative path to the source.
     #[serde(skip)]
     pub display_source: String,
 }

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -17,6 +17,8 @@ pub struct ModulePatch {
     // If enabled, evaluate the module immediately upon loading it
     #[serde(default)]
     pub load_now: bool,
+    #[serde(skip)]
+    pub display_source: String,
 }
 
 impl ModulePatch {
@@ -44,7 +46,7 @@ impl ModulePatch {
         let buf_cstr = CString::new(source.as_str()).unwrap();
         let buf_len = buf_cstr.as_bytes().len();
 
-        let name = format!("@{file_name}");
+        let name = format!("=[lovely {} \"{}\"]", &self.name, &self.display_source);
         let name_cstr = CString::new(name).unwrap();
 
         // Push the global package.preload table onto the top of the stack, saving its index.


### PR DESCRIPTION
makes the source info for a module output as `=[lovely <require-name> "<filename>"]`. Relevant discord discussion: https://canary.discord.com/channels/1116389027176787968/1214591552903716954/1285350985778204754