### PR TITLE
Add strict patch application order to pattern and regex patches

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -14,7 +14,7 @@ use log::*;
 use crop::Rope;
 use getargs::{Arg, Options};
 use itertools::Itertools;
-use patch::{Patch, PatchFile, Priority};
+use patch::{pattern, regex, Patch, PatchFile, Priority};
 use regex_lite::Regex;
 use sha2::{Digest, Sha256};
 use sys::LuaState;
@@ -448,6 +448,7 @@ impl PatchTable {
             })
             .sorted_by_key(|(_, &prio, _)| prio)
             .map(|(x, _, path)| (x, path));
+
         let copy_patches = self
             .patches
             .iter()
@@ -457,11 +458,22 @@ impl PatchTable {
             })
             .sorted_by_key(|(_, &prio, _)| prio)
             .map(|(x, _, path)| (x, path));
-        let pattern_or_regex_patches = self
+
+        let pattern_patches = self
             .patches
             .iter()
             .filter_map(|(x, prio, path)| match x {
-                Patch::Pattern(_) | Patch::Regex(_) => Some((x, prio, path)),
+                Patch::Pattern(patch) => Some((patch, prio, path)),
+                _ => None,
+            })
+            .sorted_by_key(|(_, &prio, _)| prio)
+            .map(|(x, _, path)| (x, path));
+
+        let regex_patches = self
+            .patches
+            .iter()
+            .filter_map(|(x, prio, path)| match x {
+                Patch::Regex(patch) => Some((patch, prio, path)),
                 _ => None,
             })
             .sorted_by_key(|(_, &prio, _)| prio)
@@ -488,19 +500,15 @@ impl PatchTable {
             }
         }
 
-        for (patch, path) in pattern_or_regex_patches {
-            match patch {
-                Patch::Pattern(patch) => {
-                    if patch.apply(target, &mut rope, path) {
-                        patch_count += 1;
-                    }
-                }
-                Patch::Regex(patch) => {
-                    if patch.apply(target, &mut rope, path) {
-                        patch_count += 1;
-                    }
-                }
-                _ => unreachable!(),
+        for (patch, path) in pattern_patches {
+            if patch.apply(target, &mut rope, path) {
+                patch_count += 1;
+            }
+        }
+
+        for (patch, path) in regex_patches {
+            if patch.apply(target, &mut rope, path) {
+                patch_count += 1;
             }
         }
 


### PR DESCRIPTION
In 0.6.0 (and earlier) pattern and regex patches were collected in the same step, thus meaning that their application order was derived from the order in which they were defined within a given patch file. This PR amends this and ensures that they follow the module -> copy -> pattern -> regex application order promise.