### PR TITLE
Add an optional `surrounding` key for the pattern patch

### DIFF
--- a/crates/lovely-core/Cargo.toml
+++ b/crates/lovely-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lovely-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
this makes it easier to only patch one instance of a piece of code when there's more than one in the target file with a pattern patch as opposed to needing a regex patch. For example: 

`lovely.toml`:
```toml
[[patches]]
[patches.pattern]
target = "cardarea.lua"
pattern = "card:highlight(false)"
surrounding = { before = "end", after = "if self == G.hand and G.STATE == G.SELECTING_HAND then" }
position = "at"
payload = '''
if card then
    card:highlight(false)
end
'''
match_indent = true
```

Turns this:

`cardarea.lua`:
```lua
...
    if #self.highlighted >= self.config.highlighted_limit then
        card:highlight(false)
    else
...
        end
    end
    card:highlight(false)
    if self == G.hand and G.STATE == G.SELECTING_HAND then
...
```

into this: 
`cardarea.lua`:
```lua
...
    if #self.highlighted >= self.config.highlighted_limit then
        card:highlight(false) -- Unaffected
    else
...
        end
    end
    if card then
        card:highlight(false) -- Had the patch applied
    end
    if self == G.hand and G.STATE == G.SELECTING_HAND then
...
```