### PR TITLE
Separate Detour for LOVE version < 11.5

### DIFF
--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::ffi::c_void;
 use std::panic;
+use std::ptr::null;
 
 use itertools::Itertools;
 use lovely_core::log::*;
@@ -14,14 +15,18 @@ use retour::static_detour;
 use widestring::U16CString;
 use windows::core::{s, w, PCWSTR};
 use windows::Win32::Foundation::{HINSTANCE, HWND};
+
 use windows::Win32::System::Console::{AllocConsole, SetConsoleTitleW};
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
 use windows::Win32::UI::WindowsAndMessaging::{MessageBoxW, MESSAGEBOX_STYLE};
+
+pub mod util;
 
 static RUNTIME: OnceCell<Lovely> = OnceCell::new();
 
 static_detour! {
     pub static LuaLoadbufferx_Detour: unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8,*const u8) -> u32;
+    pub static LuaLoadbuffer_Detour: unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8 ) -> u32;
 }
 
 static WIN_TITLE: Lazy<U16CString> =
@@ -37,6 +42,18 @@ unsafe extern "C" fn lua_loadbufferx_detour(
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, mode_ptr)
 }
+
+unsafe extern "C" fn lua_loadbuffer_detour(
+    state: *mut LuaState,
+    buf_ptr: *const u8,
+    size: isize,
+    name_ptr: *const u8,
+) -> u32 {
+    let rt = RUNTIME.get_unchecked();
+    rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, null())
+}
+
+
 
 #[no_mangle]
 #[allow(non_snake_case)]
@@ -71,30 +88,66 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
 
     let dump_all = args.contains(&"--dump-all".to_string());
 
-    // Initialize the lovely runtime.
-    let rt = Lovely::init(
-        &|a, b, c, d, e| LuaLoadbufferx_Detour.call(a, b, c, d, e),
-        dump_all,
-    );
-    RUNTIME
-        .set(rt)
-        .unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+    let love_version_info =
+        util::get_version("love.dll").unwrap_or_else(|err| panic!("Could not unwrap love version info"));
 
     // Quick and easy hook injection. Load the lua51.dll module at runtime, determine the address of the luaL_loadbuffer fn, hook it.
-    let handle = LoadLibraryW(w!("lua51.dll")).unwrap();
-    let proc = GetProcAddress(handle, s!("luaL_loadbufferx")).unwrap();
-    let fn_target = std::mem::transmute::<
-        _,
-        unsafe extern "C" fn(*mut c_void, *const u8, isize, *const u8, *const u8) -> u32,
-    >(proc);
+    let handle =
+        LoadLibraryW(w!("lua51.dll")).unwrap_or_else(|err| panic!("Could not find love.dll"));
 
-    LuaLoadbufferx_Detour
-        .initialize(fn_target, |a, b, c, d, e| {
-            lua_loadbufferx_detour(a, b, c, d, e)
-        })
-        .unwrap()
-        .enable()
-        .unwrap();
+    const LOVE_11_4: u32 = (11 << 16) + 4;
+    if love_version_info.dwFileVersionMS > LOVE_11_4 {
+        // Detour with loadbuferx
+
+        // Initialize the lovely runtime.
+        let rt = Lovely::init(
+            &|a, b, c, d, e| LuaLoadbufferx_Detour.call(a, b, c, d, e),
+            dump_all,
+        );
+        RUNTIME
+            .set(rt)
+            .unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+
+        let proc = GetProcAddress(handle, s!("luaL_loadbufferx"));
+
+        let fn_target = std::mem::transmute::<
+            _,
+            unsafe extern "C" fn(*mut c_void, *const u8, isize, *const u8, *const u8) -> u32,
+        >(proc);
+
+        LuaLoadbufferx_Detour
+            .initialize(fn_target, |a, b, c, d, e| {
+                lua_loadbufferx_detour(a, b, c, d, e)
+            })
+            .unwrap()
+            .enable()
+            .unwrap();
+    } else {
+        // Detour with loadbufer
+
+        // Initialize the lovely runtime.
+        let rt = Lovely::init(
+            &|a, b, c, d, e| LuaLoadbuffer_Detour.call(a, b, c, d),
+            dump_all,
+        );
+        RUNTIME
+            .set(rt)
+            .unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+
+        let proc = GetProcAddress(handle, s!("luaL_loadbuffer"))
+            .unwrap_or_else(|| panic!("func not found"));
+
+        let fn_target = std::mem::transmute::<
+            _,
+            unsafe extern "C" fn(*mut c_void, *const u8, isize, *const u8) -> u32,
+        >(proc);
+
+        LuaLoadbuffer_Detour
+            .initialize(fn_target, |a, b, c, d| lua_loadbuffer_detour(a, b, c, d))
+            .unwrap()
+            .enable()
+            .unwrap();
+    }
 
     1
 }

--- a/crates/lovely-win/src/util/mod.rs
+++ b/crates/lovely-win/src/util/mod.rs
@@ -1,0 +1,75 @@
+use std::ffi::c_void;
+
+use windows::core::w;
+use windows::core::PCWSTR;
+use windows::Win32::Storage::FileSystem::GetFileVersionInfoSizeW;
+use windows::Win32::Storage::FileSystem::GetFileVersionInfoW;
+use windows::Win32::Storage::FileSystem::VerQueryValueW;
+use windows::Win32::Storage::FileSystem::VS_FIXEDFILEINFO;
+
+pub fn get_version(dll_path: &str) -> Result<VS_FIXEDFILEINFO, Box<dyn std::error::Error>> {
+    unsafe {
+        // Encode `dll_path` as UTF-16, which is a subset of UCS2, which is what
+        // win32 wants.
+        let dll_path_wcs: Vec<_> = dll_path.encode_utf16().chain(std::iter::once(0)).collect();
+        let dll_path_pwcs = PCWSTR::from_raw(dll_path_wcs.as_ptr());
+
+        // Get file version info size.
+        let data_len = GetFileVersionInfoSizeW(dll_path_pwcs, None);
+        if data_len == 0 {
+            // Don't forget to check for errors!
+            return Err(windows::core::Error::from_win32())?;
+        }
+
+        // Win32 returns a `u32`, Rust wants a `usize`; do the conversion and
+        // make sure it's valid.
+        let data_len_usize: usize = data_len.try_into().unwrap();
+
+        /*
+        Allocate buffer.
+
+        NOTE THE USE OF `mut`!  You must not ever, EVER mutate something you've
+        told the compiler won't be mutated.
+
+        Ever.
+
+        No exceptions.
+        */
+        let mut data = vec![0u8; data_len_usize];
+
+        /*
+        Doing this makes it *slightly* harder to mess up: I can no longer
+        resize `data`, which helps prevent making pointers into it invalid.
+        */
+        let data = &mut data[..];
+
+        // Get the info.
+        let ok = GetFileVersionInfoW(
+            dll_path_pwcs,
+            0,
+            data_len,
+            // NOTE: I used `as_mut_ptr` here because I want a mutable pointer.
+            data.as_mut_ptr() as *mut c_void,
+        );
+        ok.unwrap_or_else(|err| panic!("Could not get info from dll"));
+
+        // Again, DO NOT EVER MAKE A MUTABLE POINTER TO NON-MUTABLE DATA!
+        let mut info_ptr: *mut VS_FIXEDFILEINFO = std::ptr::null_mut();
+        let mut info_len: u32 = 0;
+
+        let ok = VerQueryValueW(
+            data.as_ptr() as *const c_void,
+            w!(r"\"),
+            (&mut info_ptr) as *mut _ as *mut *mut c_void,
+            &mut info_len,
+        );
+        ok.ok()?;
+
+        // Read the info from the buffer.
+        assert!(!info_ptr.is_null());
+        assert_eq!(info_len as usize, std::mem::size_of::<VS_FIXEDFILEINFO>());
+        let info = info_ptr.read_unaligned();
+
+        Ok(info)
+    }
+}


### PR DESCRIPTION
As I explained in #145 the `luaL_loadbufferx` detour that lovely uses doesn't get hit for games that use LOVE versions before 11.5 (In my case 11.4). Instead of `luaL_loadbufferx` love.dll calls `luaL_loadbuffer` which has a very similar signature. 

This is a pretty crude implementation that uses the windows API to get the version number on love.dll and uses that to determine which detour to use for the game at runtime.

Super open to feedback as I'm not sure that this is the best solution.