### PR TITLE
Register log_dir variable after mod-dir argument is specified.

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -69,12 +69,6 @@ impl Lovely {
         };
         let mut mod_dir = dirs::config_dir().unwrap().join(game_name).join("Mods");
 
-        let log_dir = mod_dir.join("lovely").join("log");
-
-        log::init(&log_dir).unwrap_or_else(|e| panic!("Failed to initialize logger: {e:?}"));
-
-        info!("Lovely {LOVELY_VERSION}");
-
         let mut is_vanilla = false;
 
         while let Some(opt) = opts.next_arg().expect("Failed to parse argument.") {
@@ -86,6 +80,12 @@ impl Lovely {
                 _ => (),
             }
         }
+
+        let log_dir = mod_dir.join("lovely").join("log");
+
+        log::init(&log_dir).unwrap_or_else(|e| panic!("Failed to initialize logger: {e:?}"));
+
+        info!("Lovely {LOVELY_VERSION}");
 
         // Stop here if we're running in vanilla mode.
         if is_vanilla {


### PR DESCRIPTION
Made a minor change that moves the `log_dir` assignment to happen after the `mod-dir` argument is read from the Balatro application, this ensures both the mods and logs are in the same root directory.