### PR TITLE
fix: mod_dir was set incorrectly on linux

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -60,6 +60,15 @@ impl Lovely {
                 .strip_suffix(".app")
                 .expect("Parent directory of current executable path was not an .app")
                 .replace(".", "_")
+        } else if env::consts::OS == "linux" {
+            format!(
+                "love/{}",
+                PathBuf::from(&args[0])
+                    .file_stem()
+                    .expect("Failed to get file_stem component of current executable path.")
+                    .to_string_lossy()
+                    .replace(".", "_")
+            )
         } else {
             cur_exe
                 .file_stem()
@@ -67,7 +76,7 @@ impl Lovely {
                 .to_string_lossy()
                 .replace(".", "_")
         };
-        let mut mod_dir = dirs::config_dir().unwrap().join(game_name).join("Mods");
+        let mut mod_dir = dirs::data_dir().unwrap().join(game_name).join("Mods");
 
         let log_dir = mod_dir.join("lovely").join("log");
 

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -60,6 +60,12 @@ impl Lovely {
                 .strip_suffix(".app")
                 .expect("Parent directory of current executable path was not an .app")
                 .replace(".", "_")
+        } else if env::consts::OS == "linux" {
+            PathBuf::from(&args[0])
+                .file_stem()
+                .expect("Failed to get file_stem component of current executable path.")
+                .to_string_lossy()
+                .replace(".", "_")
         } else {
             cur_exe
                 .file_stem()

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -60,15 +60,6 @@ impl Lovely {
                 .strip_suffix(".app")
                 .expect("Parent directory of current executable path was not an .app")
                 .replace(".", "_")
-        } else if env::consts::OS == "linux" {
-            format!(
-                "love/{}",
-                PathBuf::from(&args[0])
-                    .file_stem()
-                    .expect("Failed to get file_stem component of current executable path.")
-                    .to_string_lossy()
-                    .replace(".", "_")
-            )
         } else {
             cur_exe
                 .file_stem()
@@ -76,7 +67,10 @@ impl Lovely {
                 .to_string_lossy()
                 .replace(".", "_")
         };
-        let mut mod_dir = dirs::data_dir().unwrap().join(game_name).join("Mods");
+        let mut mod_dir = dirs::data_dir().unwrap().join(&game_name).join("Mods");
+        if !mod_dir.is_dir() {
+            mod_dir = dirs::data_dir().unwrap().join(game_name).join("Mods");
+        }
 
         let log_dir = mod_dir.join("lovely").join("log");
 

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -60,12 +60,6 @@ impl Lovely {
                 .strip_suffix(".app")
                 .expect("Parent directory of current executable path was not an .app")
                 .replace(".", "_")
-        } else if env::consts::OS == "linux" {
-            PathBuf::from(&args[0])
-                .file_stem()
-                .expect("Failed to get file_stem component of current executable path.")
-                .to_string_lossy()
-                .replace(".", "_")
         } else {
             cur_exe
                 .file_stem()
@@ -73,8 +67,13 @@ impl Lovely {
                 .to_string_lossy()
                 .replace(".", "_")
         };
-        let mut mod_dir = dirs::data_dir().unwrap().join(&game_name).join("Mods");
-        if !mod_dir.is_dir() {
+        let mut mod_dir = dirs::config_dir().unwrap().join(&game_name).join("Mods");
+        if env::consts::OS == "linux" && !mod_dir.is_dir() {
+            let game_name = PathBuf::from(&args[0])
+                .file_stem()
+                .expect("Failed to get file_stem component of current executable path.")
+                .to_string_lossy()
+                .replace(".", "_");
             mod_dir = dirs::data_dir().unwrap().join(game_name).join("Mods");
         }
 


### PR DESCRIPTION
As per [`dirs` documentation](https://docs.rs/dirs/6.0.0/dirs/fn.config_dir.html), `dirs::config_dir` returns `/home/user/.config`, but love puts the Balatro save files into `/home/user/.local/share/love/$exe_name`. [`dirs::data_dir`](https://docs.rs/dirs/6.0.0/dirs/fn.data_dir.html) has the same behaviour as `dirs::config_dir` on Windows and MacOS, but returns `/home/user/.local/share` on Linux.

Also, since Balatro is run via `love Balatro.exe` on Linux, `game_name` gets set to `love`, so I adjusted that as well. I basically just hacked this together in a few minutes, so feel free to change it if needed. I tested that this correctly sets the mod dir to `~/.local/share/love/Balatro/Mods`.