### PR TITLE
Add macOS setup script for easier installation and launching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,9 @@ jobs:
       - name: Compress tar.gz
         run: |
           cp ./crates/lovely-unix/run_lovely_macos.sh ./target/${{ matrix.target }}/release/
+          cp ./crates/lovely-unix/setup_lovely_macos.sh ./target/${{ matrix.target }}/release/
           cd ./target/${{ matrix.target }}/release/
-          tar czfv lovely-${{ matrix.target }}.tar.gz liblovely.dylib run_lovely_macos.sh
+          tar czfv lovely-${{ matrix.target }}.tar.gz liblovely.dylib run_lovely_macos.sh setup_lovely_macos.sh
           mv "lovely-${{ matrix.target }}.tar.gz" ${{ github.workspace }}
 
       - name: Submit build artifact

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ chmod +x setup.sh
 ./setup.sh
 ```
 This will remove the quarantine attribute from `liblovely.dylib` and set up a shell alias so you can launch the game by typing `balatro` in your terminal.
+
 5. After running the setup script, you can launch the game by typing `balatro` in any terminal window, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
 
 5. Run the game by either dragging and dropping `run_lovely_macos.sh` onto `Terminal.app` in Applications > Utilities and then pressing enter, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.

--- a/README.md
+++ b/README.md
@@ -17,22 +17,18 @@ Lovely is a lua injector which embeds code into a [LÖVE 2d](https://love2d.org/
 ### Mac
 
 1. Download the [latest release](https://github.com/ethangreen-dev/lovely-injector/releases) for Mac. If you have an M-series CPU (M1, M2, etc.) then this will be `lovely-aarch64-apple-darwin.tar.gz`. If you have an Intel CPU then it will be `lovely-x86_64-apple-darwin.tar.gz`
-2. Open the .zip archive, copy `liblovely.dylib` and `run_lovely_macos.sh` into the game directory. You can navigate to the game's directory by right-clicking the game in Steam, hovering "Manage", and selecting "Browse local files".
+2. Open the .zip archive, copy `liblovely.dylib`, `setup_lovely_macos.sh`, and `run_lovely_macos.sh` into the game directory. You can navigate to the game's directory by right-clicking the game in Steam, hovering "Manage", and selecting "Browse local files".
 3. Put one or more mods into the Mac mod directory (NOT the same as the game directory). This should be `/Users/$USER/Library/Application Support/Balatro/Mods` where `$USER` is your username (if you are modding Balatro).\
 If you can't find this folder, try pressing `Shift-Command-.` (period) to show hidden files in Finder.
-4. Run the setup script by opening Terminal.app and executing:
+4. Run the setup script in the Balatro directory by opening Terminal.app and executing:
 ```bash
-cd '~/Library/Application Support/Balatro/Mods'
-chmod +x setup.sh
-./setup.sh
+cd ~/Library/Application\ Support/Steam/steamapps/common/Balatro
+chmod +x setup_lovely_macos.sh
+./setup_lovely_macos.sh
 ```
-This will remove the quarantine attribute from `liblovely.dylib` and set up a shell alias so you can launch the game by typing `balatro` in your terminal.
+This will remove the quarantine attribute from `liblovely.dylib` and ask you if you want to set up a shell alias so you can launch the game by typing `balatro` in your terminal.
 
-5. After running the setup script, you can launch the game by typing `balatro` in any terminal window, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
-
-5. Run the game by either dragging and dropping `run_lovely_macos.sh` onto `Terminal.app` in Applications > Utilities and then pressing enter, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
-
-Note: You cannot run your game through Steam on Mac due to a bug within the Steam client. You must run it with the `run_lovely_macos.sh` script.
+5. After running the setup script, you can launch the game by typing `balatro` in any terminal window, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory. Note: You cannot run your game through Steam on Mac due to a bug within the Steam client.
 
 **Important**: Mods with Lovely patch files (`lovely.toml` or in `lovely/*.toml`) **must** be installed into their own folder within the mod directory. No exceptions!
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ Lovely is a lua injector which embeds code into a [LÖVE 2d](https://love2d.org/
 2. Open the .zip archive, copy `liblovely.dylib` and `run_lovely_macos.sh` into the game directory. You can navigate to the game's directory by right-clicking the game in Steam, hovering "Manage", and selecting "Browse local files".
 3. Put one or more mods into the Mac mod directory (NOT the same as the game directory). This should be `/Users/$USER/Library/Application Support/Balatro/Mods` where `$USER` is your username (if you are modding Balatro).\
 If you can't find this folder, try pressing `Shift-Command-.` (period) to show hidden files in Finder.
-4. Run the game by either dragging and dropping `run_lovely_macos.sh` onto `Terminal.app` in Applications > Utilities and then pressing enter, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
+4. Run the setup script by opening Terminal.app and executing:
+```bash
+cd '~/Library/Application Support/Balatro/Mods'
+chmod +x setup.sh
+./setup.sh
+```
+This will remove the quarantine attribute from `liblovely.dylib` and set up a shell alias so you can launch the game by typing `balatro` in your terminal.
+5. After running the setup script, you can launch the game by typing `balatro` in any terminal window, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
+
+5. Run the game by either dragging and dropping `run_lovely_macos.sh` onto `Terminal.app` in Applications > Utilities and then pressing enter, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
 
 Note: You cannot run your game through Steam on Mac due to a bug within the Steam client. You must run it with the `run_lovely_macos.sh` script.
 

--- a/crates/lovely-unix/setup_lovely_macos.sh
+++ b/crates/lovely-unix/setup_lovely_macos.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "====== Lovely Injector macOS Setup ======"
+
+if [ -f "$SCRIPT_DIR/liblovely.dylib" ]; then
+    echo "Removing quarantine with sudo (you may be asked for your password)"
+    sudo xattr -d com.apple.quarantine "$SCRIPT_DIR/liblovely.dylib"
+    if [ $? -ne 0 ]; then
+        echo "✗ Failed to remove quarantine attribute"
+    else
+        echo "✓ Quarantine attribute removed successfully"
+    fi
+else
+    echo "✗ Could not find liblovely.dylib in the current directory"
+    exit 1
+fi
+
+echo -e "\nWould you like to set up a shell alias to launch the game from anywhere? (y/n)"
+read -r SETUP_ALIAS
+
+if [[ $SETUP_ALIAS =~ ^[Yy]$ ]]; then
+    # Determine user's shell
+    USER_SHELL=$(basename "$SHELL")
+    echo "Detected shell: $USER_SHELL"
+
+    ALIAS_COMMAND="alias balatro=\"$SCRIPT_DIR/run_lovely_macos.sh\""
+    FISH_FUNCTION="function balatro\n    \"$SCRIPT_DIR/run_lovely_macos.sh\" \$argv\nend"
+
+    case "$USER_SHELL" in
+        "bash")
+            CONFIG_FILE="$HOME/.bashrc"
+            echo -e "\n# Balatro launcher shortcut\n$ALIAS_COMMAND" >> "$CONFIG_FILE"
+            echo "✓ Added alias to $CONFIG_FILE"
+            echo "Run source $CONFIG_FILE to apply changes immediately"
+            ;;
+        "zsh")
+            CONFIG_FILE="$HOME/.zshrc"
+            echo -e "\n# Balatro launcher shortcut\n$ALIAS_COMMAND" >> "$CONFIG_FILE"
+            echo "✓ Added alias to $CONFIG_FILE"
+            echo "Run source $CONFIG_FILE to apply changes immediately"
+            ;;
+        "fish")
+            CONFIG_DIR="$HOME/.config/fish"
+            CONFIG_FILE="$CONFIG_DIR/config.fish"
+
+            # Create config directory if it doesn't exist
+            if [ ! -d "$CONFIG_DIR" ]; then
+                mkdir -p "$CONFIG_DIR"
+            fi
+
+            echo -e "\n# Balatro launcher shortcut\n$FISH_FUNCTION" >> "$CONFIG_FILE"
+            echo "✓ Added function to $CONFIG_FILE"
+            echo "Run source $CONFIG_FILE to apply changes immediately"
+            ;;
+        *)
+            echo "⚠ Unsupported shell: $USER_SHELL"
+            echo "To create an alias manually, add the following to your shell's config file:"
+            echo "alias balatro=\"$SCRIPT_DIR/run_lovely_macos.sh\""
+            ;;
+    esac
+
+    echo -e "\nSetup complete!"
+    echo "You can now launch the game by typing balatro in your terminal"
+    echo "(after sourcing your shell config or starting a new terminal session)"
+else
+    echo -e "\nSetup complete!"
+    echo "You can launch the game by running $SCRIPT_DIR/run_lovely_macos.sh"
+fi


### PR DESCRIPTION
The current macOS installation process has two pain points:
1. Users must manually remove the quarantine attribute to avoid Gatekeeper warnings (documented in #162 and #142) 
2. Launching requires either dragging a script to Terminal or navigating to the game directory

This PR adds a `setup_lovely_macos.sh` script for macOS users that:
* Removes the quarantine attribute from liblovely.dylib
* Offers to set up a shell alias (asking for permission first)
* Keeps things simple and non-intrusive

Removing the quarantine attribute requires sudo, but it's the only solution I know of right now to prevent "unidentified developer" warnings.

Note: I'm not familiar with the GitHub workflows, so those changes may need review.