### PR TITLE
fix: rename Dobby tree to dobby

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Dobby"]
-	path = crates/dobby-sys/Dobby
+	path = crates/dobby-sys/dobby
 	url = https://github.com/jmpews/Dobby.git


### PR DESCRIPTION
dobby's `build.rs` expects the path to be lowercase <https://github.com/ethangreen-dev/lovely-injector/blob/6c79d01fea1db89a6adddb96cf1623e948cd0f77/crates/dobby-sys/build.rs#L44> which (sometimes) leaves builds broken on case sensitive filesystems. and since lowercase dir names are more conventional, i changed the submodule's path instead of updating `build.rs`.