### PR TITLE
add platform-defined dynamic symbol resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblovely"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "lovely-core",
+ "once_cell",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.4",
@@ -453,6 +453,7 @@ dependencies = [
  "forward-dll",
  "itertools",
  "libc",
+ "libloading",
  "lovely-core",
  "retour",
  "widestring",

--- a/crates/liblovely/Cargo.toml
+++ b/crates/liblovely/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "liblovely"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "lovely"
+crate-type = ["staticlib"]
+
+[dependencies]
+lovely-core = { version ="0.7.1", path = "../lovely-core" }
+
+once_cell = "1.19.0"
+ctor = "0.2.7"

--- a/crates/liblovely/lovely.h
+++ b/crates/liblovely/lovely.h
@@ -1,0 +1,8 @@
+#ifndef LOVELY_H
+#define LOVELY_H
+
+void lovely_init(void *loadbufferx, void *lua_call, void *lua_pcall, void *lua_getfield, void *lua_setfield, void *lua_gettop, void *lua_settop, void *lua_pushvalue, void *lua_pushcclosure, void *lua_tolstring);
+
+int lovely_apply_patches(lua_State *L, const char *buff, size_t sz,
+    const char *name, const char *mode);
+#endif // LOVELY_H

--- a/crates/liblovely/luajit.patch
+++ b/crates/liblovely/luajit.patch
@@ -12,7 +12,7 @@ index a44f0272..f2541a5b 100644
  				   const char *name, const char *mode);
  LUALIB_API void luaL_traceback (lua_State *L, lua_State *L1, const char *msg,
 diff --git a/src/lib_aux.c b/src/lib_aux.c
-index 4b4664a7..c3b91359 100644
+index 4b4664a7..0e58ba7b 100644
 --- a/src/lib_aux.c
 +++ b/src/lib_aux.c
 @@ -22,6 +22,7 @@
@@ -27,7 +27,7 @@ index 4b4664a7..c3b91359 100644
  
  LUALIB_API lua_State *luaL_newstate(void)
  {
-+  lovely_init(lovely_loadbufferx);
++  lovely_init(lovely_loadbufferx, lua_call, lua_pcall, lua_getfield, lua_setfield, lua_gettop, lua_settop, lua_pushvalue, lua_pushcclosure, lua_tolstring, lua_toboolean, lua_topointer, lua_type, lua_typename, lua_isstring);
    lua_State *L = lua_newstate(mem_alloc, NULL);
    if (L) {
      G(L)->panic = panic;
@@ -35,7 +35,7 @@ index 4b4664a7..c3b91359 100644
  
  LUALIB_API lua_State *luaL_newstate(void)
  {
-+  lovely_init(lovely_loadbufferx);
++  lovely_init(lovely_loadbufferx, lua_call, lua_pcall, lua_getfield, lua_setfield, lua_gettop, lua_settop, lua_pushvalue, lua_pushcclosure, lua_tolstring, lua_toboolean, lua_topointer, lua_type, lua_typename, lua_isstring);
    lua_State *L;
  #if LJ_64 && !LJ_GC64
    L = lj_state_newstate(LJ_ALLOCF_INTERNAL, NULL);
@@ -74,14 +74,14 @@ index 24b660a8..daa8ef29 100644
  {
 diff --git a/src/lovely.h b/src/lovely.h
 new file mode 100644
-index 00000000..f850d867
+index 00000000..6fe5e2ec
 --- /dev/null
 +++ b/src/lovely.h
 @@ -0,0 +1,8 @@
 +#ifndef LOVELY_H
 +#define LOVELY_H
 +
-+void lovely_init(void *loadbufferx);
++void lovely_init(void *loadbufferx, void *lua_call, void *lua_pcall, void *lua_getfield, void *lua_setfield, void *lua_gettop, void *lua_settop, void *lua_pushvalue, void *lua_pushcclosure, void *lua_tolstring, void *lua_toboolean, void *lua_topointer, void *lua_type, void *lua_typename, void *lua_isstring);
 +
 +int lovely_apply_patches(lua_State *L, const char *buff, size_t sz,
 +    const char *name, const char *mode);

--- a/crates/liblovely/luajit.patch
+++ b/crates/liblovely/luajit.patch
@@ -12,7 +12,7 @@ index a44f0272..f2541a5b 100644
  				   const char *name, const char *mode);
  LUALIB_API void luaL_traceback (lua_State *L, lua_State *L1, const char *msg,
 diff --git a/src/lib_aux.c b/src/lib_aux.c
-index 4b4664a7..0e58ba7b 100644
+index 4b4664a7..31cecbd7 100644
 --- a/src/lib_aux.c
 +++ b/src/lib_aux.c
 @@ -22,6 +22,7 @@
@@ -27,7 +27,7 @@ index 4b4664a7..0e58ba7b 100644
  
  LUALIB_API lua_State *luaL_newstate(void)
  {
-+  lovely_init(lovely_loadbufferx, lua_call, lua_pcall, lua_getfield, lua_setfield, lua_gettop, lua_settop, lua_pushvalue, lua_pushcclosure, lua_tolstring, lua_toboolean, lua_topointer, lua_type, lua_typename, lua_isstring);
++  lovely_init(lovely_loadbufferx, lua_call, lua_pcall, lua_getfield, lua_setfield, lua_gettop, lua_settop, lua_pushvalue, lua_pushcclosure, lua_tolstring);
    lua_State *L = lua_newstate(mem_alloc, NULL);
    if (L) {
      G(L)->panic = panic;
@@ -35,7 +35,7 @@ index 4b4664a7..0e58ba7b 100644
  
  LUALIB_API lua_State *luaL_newstate(void)
  {
-+  lovely_init(lovely_loadbufferx, lua_call, lua_pcall, lua_getfield, lua_setfield, lua_gettop, lua_settop, lua_pushvalue, lua_pushcclosure, lua_tolstring, lua_toboolean, lua_topointer, lua_type, lua_typename, lua_isstring);
++  lovely_init(lovely_loadbufferx, lua_call, lua_pcall, lua_getfield, lua_setfield, lua_gettop, lua_settop, lua_pushvalue, lua_pushcclosure, lua_tolstring);
    lua_State *L;
  #if LJ_64 && !LJ_GC64
    L = lj_state_newstate(LJ_ALLOCF_INTERNAL, NULL);
@@ -74,14 +74,14 @@ index 24b660a8..daa8ef29 100644
  {
 diff --git a/src/lovely.h b/src/lovely.h
 new file mode 100644
-index 00000000..6fe5e2ec
+index 00000000..b1f74c67
 --- /dev/null
 +++ b/src/lovely.h
 @@ -0,0 +1,8 @@
 +#ifndef LOVELY_H
 +#define LOVELY_H
 +
-+void lovely_init(void *loadbufferx, void *lua_call, void *lua_pcall, void *lua_getfield, void *lua_setfield, void *lua_gettop, void *lua_settop, void *lua_pushvalue, void *lua_pushcclosure, void *lua_tolstring, void *lua_toboolean, void *lua_topointer, void *lua_type, void *lua_typename, void *lua_isstring);
++void lovely_init(void *loadbufferx, void *lua_call, void *lua_pcall, void *lua_getfield, void *lua_setfield, void *lua_gettop, void *lua_settop, void *lua_pushvalue, void *lua_pushcclosure, void *lua_tolstring);
 +
 +int lovely_apply_patches(lua_State *L, const char *buff, size_t sz,
 +    const char *name, const char *mode);

--- a/crates/liblovely/luajit.patch
+++ b/crates/liblovely/luajit.patch
@@ -1,0 +1,88 @@
+diff --git a/src/lauxlib.h b/src/lauxlib.h
+index a44f0272..f2541a5b 100644
+--- a/src/lauxlib.h
++++ b/src/lauxlib.h
+@@ -81,6 +81,8 @@ LUALIB_API int luaL_fileresult(lua_State *L, int stat, const char *fname);
+ LUALIB_API int luaL_execresult(lua_State *L, int stat);
+ LUALIB_API int (luaL_loadfilex) (lua_State *L, const char *filename,
+ 				 const char *mode);
++LUALIB_API int (lovely_loadbufferx) (lua_State *L, const char *buff, size_t sz,
++				   const char *name, const char *mode);
+ LUALIB_API int (luaL_loadbufferx) (lua_State *L, const char *buff, size_t sz,
+ 				   const char *name, const char *mode);
+ LUALIB_API void luaL_traceback (lua_State *L, lua_State *L1, const char *msg,
+diff --git a/src/lib_aux.c b/src/lib_aux.c
+index 4b4664a7..c3b91359 100644
+--- a/src/lib_aux.c
++++ b/src/lib_aux.c
+@@ -22,6 +22,7 @@
+ #include "lj_trace.h"
+ #include "lj_lib.h"
+ #include "lj_vmevent.h"
++#include "lovely.h"
+ 
+ #if LJ_TARGET_POSIX
+ #include <sys/wait.h>
+@@ -351,6 +352,7 @@ static void *mem_alloc(void *ud, void *ptr, size_t osize, size_t nsize)
+ 
+ LUALIB_API lua_State *luaL_newstate(void)
+ {
++  lovely_init(lovely_loadbufferx);
+   lua_State *L = lua_newstate(mem_alloc, NULL);
+   if (L) {
+     G(L)->panic = panic;
+@@ -369,6 +371,7 @@ LUALIB_API lua_State *luaL_newstate(void)
+ 
+ LUALIB_API lua_State *luaL_newstate(void)
+ {
++  lovely_init(lovely_loadbufferx);
+   lua_State *L;
+ #if LJ_64 && !LJ_GC64
+   L = lj_state_newstate(LJ_ALLOCF_INTERNAL, NULL);
+diff --git a/src/lj_load.c b/src/lj_load.c
+index 24b660a8..daa8ef29 100644
+--- a/src/lj_load.c
++++ b/src/lj_load.c
+@@ -22,6 +22,7 @@
+ #include "lj_lex.h"
+ #include "lj_bcdump.h"
+ #include "lj_parse.h"
++#include "lovely.h"
+ 
+ /* -- Load Lua source code and bytecode ----------------------------------- */
+ 
+@@ -150,7 +151,7 @@ static const char *reader_string(lua_State *L, void *ud, size_t *size)
+   return ctx->str;
+ }
+ 
+-LUALIB_API int luaL_loadbufferx(lua_State *L, const char *buf, size_t size,
++LUALIB_API int lovely_loadbufferx(lua_State *L, const char *buf, size_t size,
+ 				const char *name, const char *mode)
+ {
+   StringReaderCtx ctx;
+@@ -159,6 +160,11 @@ LUALIB_API int luaL_loadbufferx(lua_State *L, const char *buf, size_t size,
+   return lua_loadx(L, reader_string, &ctx, name, mode);
+ }
+ 
++LUALIB_API int luaL_loadbufferx(lua_State *L, const char *buf, size_t size,
++				const char *name, const char *mode)
++{
++  return lovely_apply_patches(L, buf, size, name, mode);
++}
+ LUALIB_API int luaL_loadbuffer(lua_State *L, const char *buf, size_t size,
+ 			       const char *name)
+ {
+diff --git a/src/lovely.h b/src/lovely.h
+new file mode 100644
+index 00000000..f850d867
+--- /dev/null
++++ b/src/lovely.h
+@@ -0,0 +1,8 @@
++#ifndef LOVELY_H
++#define LOVELY_H
++
++void lovely_init(void *loadbufferx);
++
++int lovely_apply_patches(lua_State *L, const char *buff, size_t sz,
++    const char *name, const char *mode);
++#endif // LOVELY_H

--- a/crates/liblovely/src/lib.rs
+++ b/crates/liblovely/src/lib.rs
@@ -24,11 +24,6 @@ unsafe extern "C" fn lovely_init(
     lua_pushvalue: *const std::ffi::c_void,
     lua_pushcclosure: *const std::ffi::c_void,
     lua_tolstring: *const std::ffi::c_void,
-    lua_toboolean: *const std::ffi::c_void,
-    lua_topointer: *const std::ffi::c_void,
-    lua_type: *const std::ffi::c_void,
-    lua_typename: *const std::ffi::c_void,
-    lua_isstring: *const std::ffi::c_void,
 ) {
     if RUNTIME.get().is_none() {
         panic::set_hook(Box::new(|x| {
@@ -49,11 +44,6 @@ unsafe extern "C" fn lovely_init(
             lua_pushvalue: std::mem::transmute(lua_pushvalue),
             lua_pushcclosure: std::mem::transmute(lua_pushcclosure),
             lua_tolstring: std::mem::transmute(lua_tolstring),
-            lua_toboolean: std::mem::transmute(lua_toboolean),
-            lua_topointer: std::mem::transmute(lua_topointer),
-            lua_type: std::mem::transmute(lua_type),
-            lua_typename: std::mem::transmute(lua_typename),
-            lua_isstring: std::mem::transmute(lua_isstring),
         };
 
         let rt = Lovely::init(

--- a/crates/liblovely/src/lib.rs
+++ b/crates/liblovely/src/lib.rs
@@ -1,19 +1,35 @@
-use lovely_core::sys::{LuaState, LUA_LIB};
-use std::{env, ptr::null};
-use std::panic;
 use lovely_core::log::*;
+use lovely_core::sys::{LuaLib, LuaState};
+use std::panic;
 
 use lovely_core::Lovely;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 
 static RUNTIME: OnceCell<Lovely> = OnceCell::new();
 
-type loadbufferx = unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32;
+type LoadBufferX =
+    unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32;
 
-static RECALL: OnceCell<loadbufferx> = OnceCell::new();
+static RECALL: OnceCell<LoadBufferX> = OnceCell::new();
 
 #[no_mangle]
-unsafe extern "C" fn lovely_init(loadbufferx: loadbufferx) {
+unsafe extern "C" fn lovely_init(
+    loadbufferx: LoadBufferX,
+    lua_call: *const std::ffi::c_void,
+    lua_pcall: *const std::ffi::c_void,
+    lua_getfield: *const std::ffi::c_void,
+    lua_setfield: *const std::ffi::c_void,
+    lua_gettop: *const std::ffi::c_void,
+    lua_settop: *const std::ffi::c_void,
+    lua_pushvalue: *const std::ffi::c_void,
+    lua_pushcclosure: *const std::ffi::c_void,
+    lua_tolstring: *const std::ffi::c_void,
+    lua_toboolean: *const std::ffi::c_void,
+    lua_topointer: *const std::ffi::c_void,
+    lua_type: *const std::ffi::c_void,
+    lua_typename: *const std::ffi::c_void,
+    lua_isstring: *const std::ffi::c_void,
+) {
     if RUNTIME.get().is_none() {
         panic::set_hook(Box::new(|x| {
             let message = format!("lovely-injector has crashed: \n{x}");
@@ -22,18 +38,42 @@ unsafe extern "C" fn lovely_init(loadbufferx: loadbufferx) {
 
         RECALL.set(loadbufferx).expect("Shit's erroring");
 
-        let rt = Lovely::init(&|a, b, c, d, e| RECALL.get_unchecked()(a, b, c, d, e), false);
-        RUNTIME.set(rt).unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+
+        let lua = LuaLib {
+            lua_call: std::mem::transmute(lua_call),
+            lua_pcall: std::mem::transmute(lua_pcall),
+            lua_getfield: std::mem::transmute(lua_getfield),
+            lua_setfield: std::mem::transmute(lua_setfield),
+            lua_gettop: std::mem::transmute(lua_gettop),
+            lua_settop: std::mem::transmute(lua_settop),
+            lua_pushvalue: std::mem::transmute(lua_pushvalue),
+            lua_pushcclosure: std::mem::transmute(lua_pushcclosure),
+            lua_tolstring: std::mem::transmute(lua_tolstring),
+            lua_toboolean: std::mem::transmute(lua_toboolean),
+            lua_topointer: std::mem::transmute(lua_topointer),
+            lua_type: std::mem::transmute(lua_type),
+            lua_typename: std::mem::transmute(lua_typename),
+            lua_isstring: std::mem::transmute(lua_isstring),
+        };
+
+        let rt = Lovely::init(
+            &|a, b, c, d, e| RECALL.get_unchecked()(a, b, c, d, e),
+            lua,
+            false,
+        );
+        RUNTIME
+            .set(rt)
+            .unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
     }
 }
 
 #[no_mangle]
 unsafe extern "C" fn lovely_apply_patches(
-        state: *mut LuaState,
-        buf_ptr: *const u8,
-        size: isize,
-        name_ptr: *const u8,
-        mode_ptr: *const u8,
+    state: *mut LuaState,
+    buf_ptr: *const u8,
+    size: isize,
+    name_ptr: *const u8,
+    mode_ptr: *const u8,
 ) -> u32 {
     let rt = RUNTIME.get_unchecked();
     rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, mode_ptr)

--- a/crates/liblovely/src/lib.rs
+++ b/crates/liblovely/src/lib.rs
@@ -1,0 +1,40 @@
+use lovely_core::sys::{LuaState, LUA_LIB};
+use std::{env, ptr::null};
+use std::panic;
+use lovely_core::log::*;
+
+use lovely_core::Lovely;
+use once_cell::sync::{Lazy, OnceCell};
+
+static RUNTIME: OnceCell<Lovely> = OnceCell::new();
+
+type loadbufferx = unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32;
+
+static RECALL: OnceCell<loadbufferx> = OnceCell::new();
+
+#[no_mangle]
+unsafe extern "C" fn lovely_init(loadbufferx: loadbufferx) {
+    if RUNTIME.get().is_none() {
+        panic::set_hook(Box::new(|x| {
+            let message = format!("lovely-injector has crashed: \n{x}");
+            error!("{message}");
+        }));
+
+        RECALL.set(loadbufferx).expect("Shit's erroring");
+
+        let rt = Lovely::init(&|a, b, c, d, e| RECALL.get_unchecked()(a, b, c, d, e), false);
+        RUNTIME.set(rt).unwrap_or_else(|_| panic!("Failed to instantiate runtime."));
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn lovely_apply_patches(
+        state: *mut LuaState,
+        buf_ptr: *const u8,
+        size: isize,
+        name_ptr: *const u8,
+        mode_ptr: *const u8,
+) -> u32 {
+    let rt = RUNTIME.get_unchecked();
+    rt.apply_buffer_patches(state, buf_ptr, size, name_ptr, mode_ptr)
+}


### PR DESCRIPTION
Depends on #198, #181 should be resolved before merge.

Adds a new crate called `liblovely` that just builds a static (.a) library. The main goal of this is to integrated directly into luajit (to create a more compatible library for any platform we can build luajit for and replace love's built in one). However, I also see it being useful in some more complex platforms where writing native code in another language and just linking to lovely would be a lot simpler then writing everything in rust (*cough cough* jailbroken iOS *cough cough*). 

This static library provides the following exports: 
- `void lovely_init(void *loadbufferx, void *lua_call, void *lua_pcall, void *lua_getfield, void *lua_setfield, void *lua_gettop, void *lua_settop, void *lua_pushvalue, void *lua_pushcclosure, void *lua_tolstring);`
  - This function is passed the original implementations for `luaL_loadbufferx`, and the rest of the fields as named.
  - This function begins the lovely startup process (loading patches, setting up logging, etc)
- `int lovely_apply_patches(lua_State *L, const char *buff, size_t const char *name, const char *mode);`
  - This function behaves the same as `luaL_loadbufferx` except it applies lovely patches

The program that is loading lovely is expected to do the following:
 - Call lovely_init sometime before the first buffer is loaded 
 - Replace calls to `luaL_loadbufferx` and `luaL_loadbuffer` with `lovely_apply_patches` (loadbuffer can pass a null pointer to the mode property)
 
Some other things that may be worth consideration:
- A method to allow external logging facilities to get lovely logs (e.g. NSLog on ios)
- A method to handle panics (so we can display popups on platforms with support)
- A method to allow control over launch args (for platforms where command line flags are not accessible)
- A method to export the current lovely version (and possibly append to/override it)
- A method to override the repo url exported in the lovely module