### PR TITLE
C-related cleanup

### DIFF
--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -1,7 +1,7 @@
 use std::ptr;
 use std::sync::OnceLock;
 use std::slice;
-use std::ffi::{c_char, c_void, CString};
+use std::ffi::{c_char, c_int, c_void, CString};
 use std::collections::VecDeque;
 
 use itertools::Itertools;
@@ -12,9 +12,9 @@ pub static LUA: OnceLock<LuaLib> = OnceLock::new();
 
 pub type LuaState = c_void;
 
-pub const LUA_GLOBALSINDEX: isize = -10002;
-pub const LUA_TNIL: isize = 0;
-pub const LUA_TBOOLEAN: isize = 1;
+pub const LUA_GLOBALSINDEX: c_int = -10002;
+pub const LUA_TNIL: c_int = 0;
+pub const LUA_TBOOLEAN: c_int = 1;
 
 macro_rules! generate {
     ($libname:ident {
@@ -39,15 +39,15 @@ macro_rules! generate {
 }
 
 generate! (LuaLib {
-    pub unsafe extern "C" fn lua_call(state: *mut LuaState, nargs: isize, nresults: isize);
-    pub unsafe extern "C" fn lua_pcall(state: *mut LuaState, nargs: isize, nresults: isize, errfunc: isize) -> isize;
-    pub unsafe extern "C" fn lua_getfield(state: *mut LuaState, index: isize, k: *const c_char);
-    pub unsafe extern "C" fn lua_setfield(state: *mut LuaState, index: isize, k: *const c_char);
-    pub unsafe extern "C" fn lua_gettop(state: *mut LuaState) -> isize;
-    pub unsafe extern "C" fn lua_settop(state: *mut LuaState, index: isize);
-    pub unsafe extern "C" fn lua_pushvalue(state: *mut LuaState, index: isize);
-    pub unsafe extern "C" fn lua_pushcclosure(state: *mut LuaState, f: *const c_void, n: isize);
-    pub unsafe extern "C" fn lua_tolstring(state: *mut LuaState, index: isize, len: *mut isize) -> *const c_char;
+    pub unsafe extern "C" fn lua_call(state: *mut LuaState, nargs: c_int, nresults: c_int);
+    pub unsafe extern "C" fn lua_pcall(state: *mut LuaState, nargs: c_int, nresults: c_int, errfunc: c_int) -> c_int;
+    pub unsafe extern "C" fn lua_getfield(state: *mut LuaState, index: c_int, k: *const c_char);
+    pub unsafe extern "C" fn lua_setfield(state: *mut LuaState, index: c_int, k: *const c_char);
+    pub unsafe extern "C" fn lua_gettop(state: *mut LuaState) -> c_int;
+    pub unsafe extern "C" fn lua_settop(state: *mut LuaState, index: c_int);
+    pub unsafe extern "C" fn lua_pushvalue(state: *mut LuaState, index: c_int);
+    pub unsafe extern "C" fn lua_pushcclosure(state: *mut LuaState, f: unsafe extern "C" fn(*mut LuaState) -> c_int, n: c_int);
+    pub unsafe extern "C" fn lua_tolstring(state: *mut LuaState, index: c_int, len: *mut usize) -> *const c_char;
 });
 
 impl LuaLib {
@@ -72,22 +72,19 @@ impl LuaLib {
 /// Load the provided buffer as a lua module with the specified name.
 /// # Safety
 /// Makes a lot of FFI calls, mutates internal C lua state.
-pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32>(
+pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, usize, *const u8, *const u8) -> u32>(
     state: *mut LuaState,
     name: &str,
     buffer: &str,
     lual_loadbufferx: &F,
 ) {
-    let buf_cstr = CString::new(buffer).unwrap();
-    let buf_len = buf_cstr.as_bytes().len();
-
     let p_name = format!("@{name}");
     let p_name_cstr = CString::new(p_name).unwrap();
 
     // Push the global package.preload table onto the top of the stack, saving its index.
     let stack_top = lua_gettop(state);
-    lua_getfield(state, LUA_GLOBALSINDEX, c"package".as_ptr() as _);
-    lua_getfield(state, -1, c"preload".as_ptr() as _);
+    lua_getfield(state, LUA_GLOBALSINDEX, c"package".as_ptr());
+    lua_getfield(state, -1, c"preload".as_ptr());
 
     // This is the index of the `package.loaded` table.
     let field_index = lua_gettop(state);
@@ -95,19 +92,19 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *con
     // Load the buffer and execute it via lua_pcall, pushing the result to the top of the stack.
     lual_loadbufferx(
         state,
-        buf_cstr.into_raw() as _,
-        buf_len as _,
+        buffer.as_ptr(),
+        buffer.len(),
         p_name_cstr.into_raw() as _,
         ptr::null(),
     );
 
     let lua_pcall_return = lua_pcall(state, 0, -1, 0);
     if lua_pcall_return == 0 {
-        lua_pushcclosure(state, lua_identity_closure as *const c_void, 1);
+        lua_pushcclosure(state, lua_identity_closure, 1);
         // Insert wrapped pcall results onto the package.preload global table.
         let module_cstr = CString::new(name).unwrap();
 
-        lua_setfield(state, field_index, module_cstr.into_raw() as _);
+        lua_setfield(state, field_index, module_cstr.into_raw());
     }
 
     lua_settop(state, stack_top);
@@ -116,21 +113,21 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, isize, *const u8, *con
 /// An override print function, copied piecemeal from the Lua 5.1 source, but in Rust.
 /// # Safety
 /// Native lua API access. It's unsafe, it's unchecked, it will probably eat your firstborn.
-pub unsafe extern "C" fn override_print(state: *mut LuaState) -> isize {
+pub unsafe extern "C" fn override_print(state: *mut LuaState) -> c_int {
     let argc = lua_gettop(state);
     let mut out = VecDeque::new();
 
     for _ in 0..argc {
         // We call Lua's builtin tostring function because we don't have access to the 5.3 luaL_tolstring
         // helper function. It's not pretty, but it works.
-        lua_getfield(state, LUA_GLOBALSINDEX, c"tostring".as_ptr() as _);
+        lua_getfield(state, LUA_GLOBALSINDEX, c"tostring".as_ptr());
         lua_pushvalue(state, -2);
         lua_call(state, 1, 1);
 
-        let mut str_len = 0_isize;
+        let mut str_len = 0usize;
         let arg_str = lua_tolstring(state, -1, &mut str_len);
 
-        let str_buf = slice::from_raw_parts(arg_str as *const u8, str_len as _);
+        let str_buf = slice::from_raw_parts(arg_str as *const u8, str_len);
         let arg_str = String::from_utf8_lossy(str_buf).to_string();
 
         out.push_front(arg_str);
@@ -148,7 +145,7 @@ pub unsafe extern "C" fn override_print(state: *mut LuaState) -> isize {
 /// be used to wrap lua values into a closure which returns that value.
 /// # Safety
 /// Makes some FFI calls, mutates internal C lua state.
-pub unsafe extern "C" fn lua_identity_closure(state: *mut LuaState) -> isize {
+pub unsafe extern "C" fn lua_identity_closure(state: *mut LuaState) -> c_int {
     // LUA_GLOBALSINDEX - 1 is where the first upvalue is located
     lua_pushvalue(state, LUA_GLOBALSINDEX - 1);
     // We just return that value

--- a/crates/lovely-unix/src/lib.rs
+++ b/crates/lovely-unix/src/lib.rs
@@ -10,12 +10,12 @@ use lovely_core::Lovely;
 static RUNTIME: OnceLock<Lovely> = OnceLock::new();
 
 static RECALL: LazyLock<
-    unsafe extern "C" fn(*mut LuaState, *const u8, isize, *const u8, *const u8) -> u32,
+    unsafe extern "C" fn(*mut LuaState, *const u8, usize, *const u8, *const u8) -> u32,
 > = LazyLock::new(|| unsafe {
     let lua_loadbufferx: unsafe extern "C" fn(
         *mut LuaState,
         *const u8,
-        isize,
+        usize,
         *const u8,
         *const u8,
     ) -> u32 = *LUA_LIBRARY.get(b"luaL_loadbufferx").unwrap();
@@ -32,7 +32,7 @@ static RECALL: LazyLock<
 unsafe extern "C" fn luaL_loadbuffer(
     state: *mut LuaState,
     buf_ptr: *const u8,
-    size: isize,
+    size: usize,
     name_ptr: *const u8,
 ) -> u32 {
     let rt = RUNTIME.get().unwrap_unchecked();
@@ -42,7 +42,7 @@ unsafe extern "C" fn luaL_loadbuffer(
 unsafe extern "C" fn lua_loadbufferx_detour(
     state: *mut LuaState,
     buf_ptr: *const u8,
-    size: isize,
+    size: usize,
     name_ptr: *const u8,
     mode_ptr: *const u8,
 ) -> u32 {


### PR DESCRIPTION
- size_t -> usize, not isize. Use of std::ffi types
- Avoid conversion to/from CString when dealing with non-null-terminated buffers from Lua