### PR TITLE
fix: init lovely per state

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -37,6 +37,9 @@ pub struct Lovely {
     loadbuffer: &'static LoadBuffer,
     patch_table: PatchTable,
     dump_all: bool,
+    // Previously seen *LuaState pointers.
+    // Note: can have false negatives. A new LuaState that happens to land in the
+    // same memory location as another one won't be detected. We currently ignore this.
     seen_states: Arc<Mutex<HashSet<usize>>>,
 }
 

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -6,7 +6,6 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 use std::path::{Path, PathBuf};
-use std::sync::Once;
 use std::time::Instant;
 use std::{env, fs};
 


### PR DESCRIPTION
Fixes #220 and an issue I never bothered filing an issue for.

Causes the lovely init from once to only on unseen states. This allows the lovely module to be accessible in threads and when restarting. Also fixes print in these contexts.