### PR TITLE
feat: load modules asap

### DIFF
--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ModulePatch {
     pub source: PathBuf,
-    pub before: String,
+    #[serde(default)]
+    pub before: Option<String>,
     pub name: String,
 
     // If enabled, evaluate the module immediately upon loading it
@@ -36,8 +37,11 @@ impl ModulePatch {
         path: &Path,
         lual_loadbufferx: &F,
     ) -> bool {
+        if self.load_now && self.before.is_none() {
+            panic!("Module patch has \"load_now\" set to true, but does not have required paramater \"before\" set");
+        }
         // Stop if we're not at the correct insertion point.
-        if self.before != file_name {
+        if self.load_now && self.before.clone().unwrap() != file_name {
             return false;
         }
 

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -43,7 +43,7 @@ impl ModulePatch {
             panic!("Error at patch file {}:\nModule \"{}\" has \"load_now\" set to true, but does not have required parameter \"before\" set", path.display(), self.name);
         }
         // Stop if we're not at the correct insertion point.
-        if self.load_now && self.before.clone().unwrap() != file_name {
+        if self.load_now && self.before.as_ref().unwrap() != file_name {
             return false;
         }
 

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -38,7 +38,7 @@ impl ModulePatch {
         lual_loadbufferx: &F,
     ) -> bool {
         if self.load_now && self.before.is_none() {
-            panic!("Module patch has \"load_now\" set to true, but does not have required paramater \"before\" set");
+            panic!("Error at patch file {}:\nModule \"{}\" has \"load_now\" set to true, but does not have required paramater \"before\" set", path.display(), self.name);
         }
         // Stop if we're not at the correct insertion point.
         if self.load_now && self.before.clone().unwrap() != file_name {

--- a/crates/lovely-core/src/patch/module.rs
+++ b/crates/lovely-core/src/patch/module.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ModulePatch {
     pub source: PathBuf,
+    // Only has meaning if `load_now` is true. Evaluate the module immediately before
+    // this file.
     #[serde(default)]
     pub before: Option<String>,
     pub name: String,
@@ -38,7 +40,7 @@ impl ModulePatch {
         lual_loadbufferx: &F,
     ) -> bool {
         if self.load_now && self.before.is_none() {
-            panic!("Error at patch file {}:\nModule \"{}\" has \"load_now\" set to true, but does not have required paramater \"before\" set", path.display(), self.name);
+            panic!("Error at patch file {}:\nModule \"{}\" has \"load_now\" set to true, but does not have required parameter \"before\" set", path.display(), self.name);
         }
         // Stop if we're not at the correct insertion point.
         if self.load_now && self.before.clone().unwrap() != file_name {


### PR DESCRIPTION
Before loses it's meaning when load_now is false (the default). Modules now can be required from all states instead of ones with a covient buffer name