### PR TITLE
Make the MacOS build universal, and in an app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,19 +76,16 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-apple-darwin
-          - aarch64-apple-darwin
+          - apple-darwin
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          target: ${{ matrix.target }}
+          targets: aarch64-${{ matrix.target }}, x86_64-${{ matrix.target }}
 
       - name: Install Mac SDK
         run: |
@@ -100,15 +97,30 @@ jobs:
         run: |
           pip3 install ziglang==0.13.0.post1 cargo-zigbuild
 
-      - name: Build
-        run: cargo zigbuild --target ${{ matrix.target }} --package lovely-unix --release
-
-      - name: Compress tar.gz
+      - name: Install lipo for universal binary creation
         run: |
-          cp ./crates/lovely-unix/run_lovely_macos.sh ./target/${{ matrix.target }}/release/
-          cd ./target/${{ matrix.target }}/release/
-          tar czfv lovely-${{ matrix.target }}.tar.gz liblovely.dylib run_lovely_macos.sh
-          mv "lovely-${{ matrix.target }}.tar.gz" ${{ github.workspace }}
+          sudo apt install golang-go
+          go install github.com/konoui/lipo@latest
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+    
+      - name: Build arm64
+        run: cargo zigbuild --target aarch64-${{ matrix.target }} --package lovely-unix --release
+
+      - name: Build x86_64
+        run: cargo zigbuild --target x86_64-${{ matrix.target }} --package lovely-unix --release
+
+      - name: Make macOS app bundle
+        run: |
+          mkdir -p BalatroLovely.app/Contents/Macos
+          cp ./crates/lovely-unix/run_lovely_macos.sh ./BalatroLovely.app/Contents/Macos
+          mkdir -p BalatroLovely.app/Contents/Resources
+          lipo -create -output BalatroLovely.app/Contents/Resources/liblovely.dylib \
+            ./target/aarch64-${{ matrix.target }}/release/liblovely.dylib \
+            ./target/x86_64-${{ matrix.target }}/release/liblovely.dylib
+          cp ./crates/lovely-unix/Info.plist ./BalatroLovely.app/Contents/
+          echo "APPLLoVe" > ./BalatroLovely.app/Contents/PkgInfo
+
+          tar czfv lovely-${{ matrix.target }}.tar.gz BalatroLovely.app
 
       - name: Submit build artifact
         env:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Lovely is a lua injector which embeds code into a [LÖVE 2d](https://love2d.org/
 
 ### Mac
 
-1. Download the [latest release](https://github.com/ethangreen-dev/lovely-injector/releases) for Mac. If you have an M-series CPU (M1, M2, etc.) then this will be `lovely-aarch64-apple-darwin.tar.gz`. If you have an Intel CPU then it will be `lovely-x86_64-apple-darwin.tar.gz`
-2. Open the .zip archive, copy `liblovely.dylib` and `run_lovely_macos.sh` into the game directory. You can navigate to the game's directory by right-clicking the game in Steam, hovering "Manage", and selecting "Browse local files".
-3. Put one or more mods into the Mac mod directory (NOT the same as the game directory). This should be `/Users/$USER/Library/Application Support/Balatro/Mods` where `$USER` is your username (if you are modding Balatro).\
-If you can't find this folder, try pressing `Shift-Command-.` (period) to show hidden files in Finder.
-4. Run the game by either dragging and dropping `run_lovely_macos.sh` onto `Terminal.app` in Applications > Utilities and then pressing enter, or by executing `sh run_lovely_macos.sh` in the terminal within the game directory.
+1. Download the [latest release](https://github.com/ethangreen-dev/lovely-injector/releases) for Mac.
+2. Open the archive, and click on `BalatroLovely.app`, this will raise a an alert saying "Apple could not verify “BalatroLovely.app'". Click "Done"
+3. Open `System Preferences`, then `Security & Privacy`, and find `"BalatroLovely.app" was blocked to protect your Mac`. Click "Open Anyway" to allow the app to run.
+4. This will open a new dialog, press `Open Anyway` on this dialog as well.
+5. It will then as for your password or fingerprint to allow the app to run. Enter your password or use your fingerprint.
+6. Re-click on `BalatroLovely.app` to run the modded game.
 
-Note: You cannot run your game through Steam on Mac due to a bug within the Steam client. You must run it with the `run_lovely_macos.sh` script.
+Note: You cannot run your game through Steam on Mac due to a bug within the Steam client. You must run it with the `BalatroLovely.app` app bundle.
 
 **Important**: Mods with Lovely patch files (`lovely.toml` or in `lovely/*.toml`) **must** be installed into their own folder within the mod directory. No exceptions!
 

--- a/crates/lovely-unix/Info.plist
+++ b/crates/lovely-unix/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSRequiresNativeExecution</key>
+	<true/>
+	<key>LSArchitecturePriority</key>
+	<array>
+		<string>arm64</string>
+		<string>x86_64</string>
+	</array>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>run_lovely_macos.sh</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.BalatroLovely.ethangreen</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>BalatroLovely</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>LoVe</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.7</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<false/>
+</dict>
+</plist>

--- a/crates/lovely-unix/run_lovely_macos.sh
+++ b/crates/lovely-unix/run_lovely_macos.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 gamename="Balatro"
-defaultpath="/Users/$USER/Library/Application Support/Steam/steamapps/common/$gamename"
 
-export DYLD_INSERT_LIBRARIES=liblovely.dylib
+# Get the absolute path to where we are running from
+SCRIPT_FOLDER="$(dirname -- "${BASH_SOURCE[0]}")"
+APP_FOLDER="$(dirname -- "$SCRIPT_FOLDER")"
+
+# Specify the complete path to the library in the app bundle
+export DYLD_INSERT_LIBRARIES="$APP_FOLDER/Resources/liblovely.dylib"
+
+defaultpath="/Users/$USER/Library/Application Support/Steam/steamapps/common/$gamename"
 
 cd "$defaultpath"
 ./$gamename.app/Contents/MacOS/love "$@"


### PR DESCRIPTION
Makes the library a universal binary by packing both architectures into the same file, and then putting that into a *really* basic app bundle to make it easier to add the security exception since it will now be in System Preferences. Also updated the README with the new instructions to run it.