### PR TITLE
feat: reload on lovely module

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -204,8 +204,8 @@ impl Lovely {
         let patch_table = binding.read().unwrap();
         {
             if !sys::is_module_preloaded(state, "lovely") {
-                let closure = sys::override_print;
-                sys::lua_pushcclosure(state, closure, 0);
+                let closure: LuaFunc = sys::override_print;
+                state.push(closure);
                 sys::lua_setfield(state, sys::LUA_GLOBALSINDEX, c"print".as_ptr());
 
                 // Inject Lovely functions into the runtime.

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -33,7 +33,6 @@ type LoadBuffer =
     dyn Fn(*mut LuaState, *const u8, usize, *const u8, *const u8) -> u32 + Send + Sync + 'static;
 
 unsafe extern "C" fn reload_patches(state: *mut LuaState) -> c_int {
-    info!("hi mom");
     let result = panic::catch_unwind(|| {
         let lovely = &RUNTIME.get().unwrap();
         let new_table = PatchTable::load(&lovely.mod_dir).with_loadbuffer(lovely.loadbuffer);

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -64,6 +64,7 @@ generate! (LuaLib {
     pub unsafe extern "C" fn lual_register(state: *mut LuaState, libname: *const char, l: *const c_void);
     pub unsafe extern "C" fn lua_pushstring(state: *mut LuaState, string: *const char);
     pub unsafe extern "C" fn lua_pushnumber(state: *mut LuaState, number: f64);
+    pub unsafe extern "C" fn lua_pushboolean(state: *mut LuaState, bool: c_int);
     pub unsafe extern "C" fn lua_settable(state: *mut LuaState, index: isize);
     pub unsafe extern "C" fn lua_createtable(state: *mut LuaState, narr: isize, nrec: isize);
 });
@@ -87,6 +88,7 @@ impl LuaLib {
             lual_register: *library.get(b"luaL_register").unwrap(),
             lua_pushstring: *library.get(b"lua_pushstring").unwrap(),
             lua_pushnumber: *library.get(b"lua_pushnumber").unwrap(),
+            lua_pushboolean: *library.get(b"lua_pushboolean").unwrap(),
             lua_settable: *library.get(b"lua_settable").unwrap(),
             lua_createtable: *library.get(b"lua_createtable").unwrap(),
         }
@@ -134,6 +136,12 @@ impl Pushable for &str {
 impl Pushable for isize {
     unsafe fn push(&self, state: *mut LuaState) {
         lua_pushnumber(state, *self as _);
+    }
+}
+
+impl Pushable for bool {
+    unsafe fn push(&self, state: *mut LuaState) {
+        lua_pushboolean(state, *self as _);
     }
 }
 

--- a/crates/lovely-unix/src/lib.rs
+++ b/crates/lovely-unix/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 
 use lovely_core::Lovely;
 
-static RUNTIME: OnceLock<Lovely> = OnceLock::new();
+static RUNTIME: OnceLock<&Lovely> = OnceLock::new();
 
 type LoadBuffer =
     unsafe extern "C" fn(*mut LuaState, *const u8, usize, *const u8, *const u8) -> u32;

--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -19,7 +19,7 @@ use windows::Win32::System::Console::{AllocConsole, SetConsoleTitleW};
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
 use windows::Win32::UI::WindowsAndMessaging::{MessageBoxW, MESSAGEBOX_STYLE};
 
-static RUNTIME: OnceLock<Lovely> = OnceLock::new();
+static RUNTIME: OnceLock<&Lovely> = OnceLock::new();
 
 static_detour! {
     pub static LuaLoadbufferx_Detour: unsafe extern "C" fn(*mut LuaState, *const u8, usize, *const u8,*const u8) -> u32;


### PR DESCRIPTION
Adds a new method on the lovely module reload_patches, which will reload lovely patches, and return either `true` or `false, err` where err is the error.

Depends on #285 