### PR TITLE
Allow multiple targets on a patch 

### DIFF
--- a/crates/lovely-core/src/patch/copy.rs
+++ b/crates/lovely-core/src/patch/copy.rs
@@ -4,6 +4,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use super::Target;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -15,7 +16,7 @@ pub enum CopyPosition {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CopyPatch {
     pub position: CopyPosition,
-    pub target: String,
+    pub target: Target,
     pub sources: Vec<PathBuf>,
 
     // Currently unused.
@@ -28,7 +29,7 @@ impl CopyPatch {
     /// If the name *is* a valid target of this patch, prepend or append the source file(s)'s contents
     /// and return true.
     pub fn apply(&self, target: &str, rope: &mut Rope, path: &Path) -> bool {
-        if self.target != target {
+        if !self.target.can_apply(target) {
             return false;
         }
 

--- a/crates/lovely-core/src/patch/mod.rs
+++ b/crates/lovely-core/src/patch/mod.rs
@@ -79,6 +79,13 @@ pub enum Patch {
     Module(ModulePatch),
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum Target {
+    Single(String),
+    Multi(Vec<String>)
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum InsertPosition {

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use wildmatch::WildMatch;
 
-use super::InsertPosition;
+use super::{InsertPosition, Target};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PatternPatch {
@@ -17,7 +17,7 @@ pub struct PatternPatch {
 
     // The position to insert the target at. `PatternAt::At` replaces the matched line entirely.
     pub position: InsertPosition,
-    pub target: String,
+    pub target: Target,
     // pub payload_files: Option<Vec<String>>,
     pub payload: String,
     pub match_indent: bool,
@@ -36,7 +36,7 @@ impl PatternPatch {
     /// Apply the pattern patch onto the rope.
     /// The return value will be `true` if the rope was modified.
     pub fn apply(&self, target: &str, rope: &mut Rope, path: &Path) -> bool {
-        if self.target != target {
+        if !self.target.can_apply(target) {
             return false;
         }
 

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -11,11 +11,11 @@ use serde::{Serialize, Deserialize};
 
 use crate::chunk_vec_cursor::IntoCursor;
 
-use super::InsertPosition;
+use super::{InsertPosition, Target};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RegexPatch {
-    pub target: String,
+    pub target: Target,
 
     // The Regex pattern that will be used to both match and create capture groups.
     pub pattern: String,
@@ -49,7 +49,7 @@ pub struct RegexPatch {
 
 impl RegexPatch {
     pub fn apply(&self, target: &str, rope: &mut Rope, path: &Path) -> bool {
-        if self.target != target {
+        if !self.target.can_apply(target) {
             return false;
         }
 


### PR DESCRIPTION
Pattern/regex/copy patches can now be written like so:
```toml
[[patches]]
[patches.regex]
target = ["card.lua", "cardarea.lua"] # this is what changed
pattern = ".*"
position = "after"
payload = "-- [[hi!]]"
match_indent = true
```

This allows you to apply a single patch to multiple files.
The old target format still works fine.
This PR addresses #294.