### PR TITLE
Add name fields to patches

### DIFF
--- a/crates/lovely-core/src/patch/copy.rs
+++ b/crates/lovely-core/src/patch/copy.rs
@@ -17,6 +17,9 @@ pub struct CopyPatch {
     pub position: CopyPosition,
     pub target: String,
     pub sources: Vec<PathBuf>,
+
+    // Currently unused.
+    pub name: Option<String>
 }
 impl CopyPatch {
     /// Apply a copy patch onto the provided buffer and name.

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -27,6 +27,9 @@ pub struct PatternPatch {
     /// We keep this field around for legacy compat. It doesn't do anything (and never has).
     #[serde(default)]
     pub overwrite: bool,
+
+    // Currently unused.
+    pub name: Option<String>
 }
 
 impl PatternPatch {

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -42,6 +42,9 @@ pub struct RegexPatch {
     // If enabled, whitespace is ignored unless escaped
     #[serde(default)]
     pub verbose: bool,
+
+    // Currently unused.
+    pub name: Option<String>
 }
 
 impl RegexPatch {


### PR DESCRIPTION
I believe this is intended to be used with lovely-sdk. 
This addresses #252.
The "name" field is optional, and if included takes the following form:
```toml
[[patches]]
[patches.pattern]
#omitted: target, pattern, payload, position, match_indents
name = "my_patch"
```
