### PR TITLE
feat: lua variable store

### DIFF
--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -138,6 +138,13 @@ impl Pushable for String {
     }
 }
 
+impl Pushable for &String {
+    unsafe fn push(&self, state: *mut LuaState) {
+        let value = format!("{self}\0");
+        lua_pushstring(state, value.as_ptr() as _);
+    }
+}
+
 impl Pushable for &str {
     unsafe fn push(&self, state: *mut LuaState) {
         let value = CString::new(*self).unwrap();


### PR DESCRIPTION
Adds 3 new methods to the lovely module, `set_var`, `get_var` and `remove_var`.  These values take strings (2 for `set_var`, 1 for the others), and are used to store strings on the lovely runtime variable. These strings are accessible across states in the same process, (so they can be used for cross thread storage, and also to store info after calling `love.event.quit("restart")`.

These may also be useful for configuring lovely config options from lua in the future.