### PR TITLE
Implement runtime patch creation

### DIFF
--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -78,6 +78,9 @@ generate! (LuaLib {
     pub unsafe extern "C" fn lua_settable(state: *mut LuaState, index: isize);
     pub unsafe extern "C" fn lua_createtable(state: *mut LuaState, narr: isize, nrec: isize);
     pub unsafe extern "C" fn lual_checklstring(state: *mut LuaState, index: c_int, len: *mut usize) -> *const char;
+    pub unsafe extern "C" fn lua_isnumber(state: *mut LuaState, index: c_int) -> c_int;
+    pub unsafe extern "C" fn lua_isstring(state: *mut LuaState, index: c_int) -> c_int;
+    pub unsafe extern "C" fn lua_remove(state: *mut LuaState, index: c_int);
 });
 
 impl LuaLib {
@@ -103,6 +106,9 @@ impl LuaLib {
             lua_settable: *library.get(b"lua_settable").unwrap(),
             lua_createtable: *library.get(b"lua_createtable").unwrap(),
             lual_checklstring: *library.get(b"luaL_checklstring").unwrap(),
+            lua_isnumber: *library.get(b"lua_isnumber").unwrap(),
+            lua_isstring: *library.get(b"lua_isstring").unwrap(),
+            lua_remove: *library.get(b"lua_remove").unwrap()
         }
     }
 }


### PR DESCRIPTION
Very rough draft PR for a feature that may not get added.
This allows for a function to be called from Lua space, creating a new patch as if it were a plain TOML file.

Currently this is just a demo, seeing what could be done.
The idea is to eventually allow people to have something like a `patches.lua` file, loading before the game (but after love initializes).
This would allow users to call whatever Love2d functions they want for information about, say, the system, and use that to determine whether to create a certain patch or not.
It would also allow people to avoid directly using the TOML format, which is a very minor concern. It's still worth mentioning.

Additionally, for specifically Balatro and perhaps other games that have mod loaders based on priority, it could slightly simplify cross-mod patching.
If someone's mod loads before another's it can make a patch from the Lua side of things given any number of conditions, mainly whether that mod is loaded. However, unlike with a traditional TOML patch, it is much easier to check for things like the other mod's version.

Currently this PR only supports pattern patches, and is written in a way that is unfriendly to adding support for regex/module/copy patches. If the other maintainers see this feature as something worth implementing, I will rewrite this PR to be "healthier" and less hacked in.