### PR TITLE
Check needs_patching before calling apply_patches from Lua

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -621,7 +621,11 @@ unsafe extern "C" fn apply_patches(lua_state: *mut LuaState) -> c_int {
     let buf = check_lua_string(lua_state, 2);
     let result = panic::catch_unwind(|| {
         let binding = RUNTIME.get().unwrap().patch_table.read().unwrap();
-        lua_state.push(binding.apply_patches(&buf_name, &buf, lua_state));
+        if binding.needs_patching(&buf_name) {
+            lua_state.push(binding.apply_patches(&buf_name, &buf, lua_state));
+        } else {
+            lua_state.push(buf)
+        }
     });
     if result.is_ok() {
         1


### PR DESCRIPTION
Currently, `apply_patches` (rust) is unconditionally called when `apply_patches` (lua) is called. 
This, among other things, wastes resources and causes lovely to output a message resembling `0 patches applied to some_buf_name`, which is undesirable.

This is fixed here by calling `needs_patching` to check whether the provided buffer actually needs to have any patches applied to it. This is in line with the rust code that calls `apply_patches` (rust), checking that condition beforehand.