### PR TITLE
Add optional payload field to copy patches

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -444,7 +444,18 @@ impl PatchTable {
                 for patch in &mut patch_file.patches[..] {
                     match patch {
                         Patch::Copy(ref mut x) => {
-                            x.sources = x.sources.iter_mut().map(|x| mod_dir.join(x)).collect();
+                            if let Some(ref mut sources) = x.sources {
+                                x.sources = Some(sources.iter_mut().map(|x| mod_dir.join(x)).collect())
+                            }
+
+                            if x.sources.is_none() && x.payload.is_none() {
+                                let name = match &x.name {
+                                    None => "".to_string(),
+                                    Some(name ) => format!(" \"{name}\"")
+                                };
+                                bail!("Error at patch file {}:\nCopy{name} does not have a \"payload\" or \"sources\" parameter set.", mod_relative_path.display())
+                            }
+
                             x.target.insert_into(&mut targets);
                         }
                         Patch::Module(ref mut x) => {

--- a/crates/lovely-core/src/patch/copy.rs
+++ b/crates/lovely-core/src/patch/copy.rs
@@ -17,7 +17,7 @@ pub enum CopyPosition {
 pub struct CopyPatch {
     pub position: CopyPosition,
     pub target: Target,
-    pub sources: Vec<PathBuf>,
+    pub sources: Option<Vec<PathBuf>>,
 
     pub payload: Option<String>,
 
@@ -35,25 +35,29 @@ impl CopyPatch {
             return false;
         }
 
+        
+
         // Merge the provided payloads into a single buffer. Each source path should
         // be made absolute by the patch loader.
-        for source in self.sources.iter() {
-            let contents = fs::read_to_string(source).unwrap_or_else(|e| {
-                panic!(
-                    "Failed to read source file at {source:?} for copy patch from {}: {e:?}",
-                    path.display()
-                )
-            });
+        if let Some(ref sources) = self.sources {
+            for source in sources.iter() {
+                let contents = fs::read_to_string(source).unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to read source file at {source:?} for copy patch from {}: {e:?}",
+                        path.display()
+                    )
+                });
 
-            // Append or prepend the patch's lines onto the provided buffer.
-            match self.position {
-                CopyPosition::Prepend => {
-                    rope.insert(0, "\n");
-                    rope.insert(0, &contents);
-                }
-                CopyPosition::Append => {
-                    rope.insert(rope.byte_len(), "\n");
-                    rope.insert(rope.byte_len(), &contents);
+                // Append or prepend the patch's lines onto the provided buffer.
+                match self.position {
+                    CopyPosition::Prepend => {
+                        rope.insert(0, "\n");
+                        rope.insert(0, &contents);
+                    }
+                    CopyPosition::Append => {
+                        rope.insert(rope.byte_len(), "\n");
+                        rope.insert(rope.byte_len(), &contents);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Here, copy patches would be able to have a `payload` field set. `payload` and `sources` can both be present, one can be missing, but a copy patch cannot have neither.