### PR TITLE
feat: blacklist

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -361,10 +361,11 @@ impl PatchTable {
         if fs::exists(&blacklist_file)? {
             let text = fs::read_to_string(blacklist_file).context("Could not read blacklist")?;
 
-            for line in text.lines() {
-                if line.is_empty() || line.starts_with("#") { continue; }
-                blacklist.insert(line.to_string());
-            }
+            blacklist.extend(
+                text.lines()
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .map(|line| line.to_string())
+            );
         } else {
             info!("No blacklist.txt in Mods/lovely.");
         }
@@ -384,7 +385,7 @@ impl PatchTable {
                 }
                 !blacklisted
             })
-            .map(|x| x.path())
+        .map(|x| x.path())
             .filter(|x| {
                 let ignore_file = x.join(".lovelyignore");
                 let dirname = x


### PR DESCRIPTION
Implements a blacklist file to prevent mods for loading (preparation for zip loading).

The format is basically a 1-to-1 rip off of everest's. There is a text file at `Mods/lovely/blacklist.txt` that has one element per line. If that line starts with # it's ignored (comment) and if it matches a mod's folder/zip name identically, that mod is disabled.

Some questions for reviewer:
- Should we make an example file on startup to make it more obvious it exists and how to use it? (everest does this <https://github.com/EverestAPI/Everest/blob/a1785636ba4038f1e0af594e7b3428f8e40470c5/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs#L125-L128>)
- Should we deprecate `.lovelyignore`?