### PR TITLE
Add context to error occurring with lovely being mistakenly run

### DIFF
--- a/crates/lovely-win/Cargo.toml
+++ b/crates/lovely-win/Cargo.toml
@@ -14,7 +14,7 @@ itertools = "0.13.0"
 libc = "0.2.141"
 widestring = "1.0.2"
 libloading = "0.8.6"
-
+anyhow = "1.0.100"
 
 [dependencies.retour]
 git = "https://github.com/Hpmason/retour-rs.git"

--- a/crates/lovely-win/src/lualib.rs
+++ b/crates/lovely-win/src/lualib.rs
@@ -1,8 +1,9 @@
-use libloading::Library;
+
+use libloading::{Error, Library};
 use lovely_core::sys::LuaLib;
 
 
-pub unsafe fn get_lualib() -> LuaLib {
-    let library = Library::new("lua51.dll").unwrap();
-    LuaLib::from_library(&library)
+pub unsafe fn get_lualib() -> Result<LuaLib, Error> {
+    let library = Library::new("lua51.dll")?;
+    Ok(LuaLib::from_library(&library))
 }


### PR DESCRIPTION
When lovely's version.dll is loaded by a process which, for whatever reason, fails to contain lua51.dll:
<img width="394" height="489" alt="image" src="https://github.com/user-attachments/assets/46ba51b8-3bc3-4188-ad7a-c6bcb38da039" />
(Love2D programs error earlier than this, this can never appear with Love2D)

Second paragraph contains the context this PR adds.