### PR TITLE
resolve some clippy warnings

### DIFF
--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -60,8 +60,8 @@ unsafe extern "C" fn getvar(state: *mut LuaState) -> c_int {
     let lovely = &RUNTIME.get().unwrap();
     let vars = lovely.lua_vars.read().unwrap();
     let val = vars.get(&key);
-    if val.is_some() {
-        state.push(val.unwrap());
+    if let Some(val) = val {
+        state.push(val);
         return 1;
     }
     0
@@ -81,8 +81,8 @@ unsafe extern "C" fn removevar(state: *mut LuaState) -> c_int {
     let lovely = &RUNTIME.get().unwrap();
     let mut vars = lovely.lua_vars.write().unwrap();
     let val = vars.remove(&key);
-    if val.is_some() {
-        state.push(val.unwrap());
+    if let Some(val) = val {
+        state.push(val);
         return 1;
     }
     0

--- a/crates/lovely-core/src/sys.rs
+++ b/crates/lovely-core/src/sys.rs
@@ -52,7 +52,7 @@ unsafe extern "C" fn lua_return_values(state: *mut LuaState) -> c_int {
 
 // HACK: Panics if not inlined?
 #[inline(always)]
-pub unsafe fn check_lua_string(state: *mut LuaState, index: c_int) -> String {
+pub(crate) unsafe fn check_lua_string(state: *mut LuaState, index: c_int) -> String {
     let mut str_len = 0usize;
     let arg_str = lual_checklstring(state, index, &mut str_len);
 
@@ -108,7 +108,7 @@ impl LuaLib {
 }
 
 // TODO: implement all lua methods on this(?)
-pub trait LuaStateTrait {
+pub(crate) trait LuaStateTrait {
     unsafe fn push<P: Pushable>(self, obj: P);
     unsafe fn push_closure(self, func: LuaFunc, vals: c_int);
 }
@@ -184,7 +184,7 @@ pub struct LuaTable {
 }
 
 impl LuaTable {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         LuaTable {
             var: vec![],
         }
@@ -293,7 +293,7 @@ pub unsafe fn load_module<F: Fn(*mut LuaState, *const u8, usize, *const u8, *con
 // Checks if a module is in the preload table. Used to check if lovely was already initalized
 // # Safety
 // Uses the native lua API. I'm also pretty sure I it bikes without a helmet.
-pub unsafe fn is_module_preloaded(state: *mut LuaState, name: &str) -> bool {
+pub(crate) unsafe fn is_module_preloaded(state: *mut LuaState, name: &str) -> bool {
     let name_cstr = CString::new(name).unwrap();
     let stack_top = lua_gettop(state);
     lua_getfield(state, LUA_GLOBALSINDEX, c"package".as_ptr());
@@ -303,7 +303,7 @@ pub unsafe fn is_module_preloaded(state: *mut LuaState, name: &str) -> bool {
     let res = lua_type(state, -1) != LUA_TNIL;
 
     lua_settop(state, stack_top);
-    return res;
+    res
 }
 
 /// An override print function, copied piecemeal from the Lua 5.1 source, but in Rust.

--- a/crates/lovely-win/src/lib.rs
+++ b/crates/lovely-win/src/lib.rs
@@ -93,8 +93,8 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
     let handle = LoadLibraryW(w!("lua51.dll")).unwrap();
     let proc = GetProcAddress(handle, s!("luaL_loadbufferx")).unwrap();
     let fn_target = std::mem::transmute::<
-        _,
-        unsafe extern "C" fn(*mut c_void, *const u8, usize, *const u8, *const u8) -> u32,
+        unsafe extern "system" fn() -> isize, 
+        unsafe extern "C" fn(*mut std::ffi::c_void, *const u8, usize, *const u8, *const u8) -> u32
     >(proc);
 
     LuaLoadbufferx_Detour
@@ -107,9 +107,9 @@ unsafe extern "system" fn DllMain(_: HINSTANCE, reason: u32, _: *const c_void) -
 
     let proc = GetProcAddress(handle, s!("luaL_loadbuffer")).unwrap();
     let fn_target = std::mem::transmute::<
-        _,
-        unsafe extern "C" fn(*mut c_void, *const u8, usize, *const u8) -> u32,
-        >(proc);
+        unsafe extern "system" fn() -> isize, 
+        unsafe extern "C" fn(*mut std::ffi::c_void, *const u8, usize, *const u8) -> u32
+    >(proc);
 
     LuaLoadbuffer_Detour
         .initialize(fn_target, |a, b, c, d| {


### PR DESCRIPTION
This resolves 1 warning about an unnecessary `return` at the end of a function, two for omitted generics in `transmute`, and a bunch for `pub unsafe fn`s that had no `/// # Safety` (by making them `pub(crate)` instead.)