### PR TITLE
fix: wrong dir on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
 name = "lovely-win"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "forward-dll",
  "itertools",
  "libc",

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -133,7 +133,7 @@ impl Lovely {
                     .to_string_lossy()
                     .replace(".", "_")
             };
-            dirs::config_dir().unwrap().join(game_name).join("Mods")
+            dirs::data_dir().unwrap().join(game_name).join("Mods")
         };
 
         let mut is_vanilla = false;


### PR DESCRIPTION
Switches from [config_dir](https://docs.rs/dirs/latest/dirs/fn.config_dir.html) to [data_dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html) which fixes an issue where on linux it used a different directory than love did. This should not change the behaviour on windows or macOS.

This is kinda a breaking change so it should be mentioned in the release notes.