### PR TITLE
fix: hard coded balatro in `run_lovely_linux.sh`

### DIFF
--- a/crates/lovely-unix/run_lovely_linux.sh
+++ b/crates/lovely-unix/run_lovely_linux.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 gamename="Balatro"
+exename="$gamename"
 defaultpath="/home/$USER/.local/share/Steam/steamapps/common/$gamename"
 
 cd "$defaultpath"
-LD_PRELOAD=liblovely.so love $gamename.exe "$@"
+LD_PRELOAD=liblovely.so love $exename.exe "$@"

--- a/crates/lovely-unix/run_lovely_macos.sh
+++ b/crates/lovely-unix/run_lovely_macos.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 gamename="Balatro"
+exename="$gamename"
 defaultpath="/Users/$USER/Library/Application Support/Steam/steamapps/common/$gamename"
 
 export DYLD_INSERT_LIBRARIES=liblovely.dylib
 
 cd "$defaultpath"
-./$gamename.app/Contents/MacOS/love "$@"
+./$exename.app/Contents/MacOS/love "$@"


### PR DESCRIPTION
Fixes beatblock people needing to edit the exe name and matches the macos behaviour. (Not actually tested by beatblock people)