### PR TITLE
Allow glob targets

### DIFF
--- a/crates/lovely-core/benches/patches.rs
+++ b/crates/lovely-core/benches/patches.rs
@@ -39,7 +39,7 @@ fn pattern_patches_no_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: None,
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -49,7 +49,7 @@ fn pattern_patches_no_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: None,
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -59,7 +59,7 @@ fn pattern_patches_no_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: None,
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -69,7 +69,7 @@ fn pattern_patches_no_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: None,
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
         ]
     })
@@ -87,7 +87,7 @@ fn pattern_patches_with_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(1),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -97,7 +97,7 @@ fn pattern_patches_with_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(5),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -107,7 +107,7 @@ fn pattern_patches_with_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(1),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -117,7 +117,7 @@ fn pattern_patches_with_match() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(2),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
         ]
     })
@@ -136,7 +136,7 @@ fn regex_patches_no_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: None,
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -147,7 +147,7 @@ fn regex_patches_no_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: None,
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -158,7 +158,7 @@ fn regex_patches_no_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: None,
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -169,7 +169,7 @@ fn regex_patches_no_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: None,
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
         ]
     })
@@ -188,7 +188,7 @@ fn regex_patches_with_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(1),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -199,7 +199,7 @@ fn regex_patches_with_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(5),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -210,7 +210,7 @@ fn regex_patches_with_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(1),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -221,7 +221,7 @@ fn regex_patches_with_match() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(2),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
         ]
     })
@@ -239,7 +239,7 @@ fn pattern_patches_position() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(1),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -249,7 +249,7 @@ fn pattern_patches_position() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(1),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
             PatternPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -259,7 +259,7 @@ fn pattern_patches_position() -> &'static [PatternPatch] {
                 match_indent: false,
                 times: Some(1),
                 overwrite: false,
-                name: None,
+                name: None, silent: false,
             },
         ]
     })
@@ -278,7 +278,7 @@ fn regex_patches_position() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(1),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -289,7 +289,7 @@ fn regex_patches_position() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(1),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
             RegexPatch {
                 target: Target::Single("sample_buffer.txt".to_string()),
@@ -300,7 +300,7 @@ fn regex_patches_position() -> &'static [RegexPatch] {
                 line_prepend: String::new(),
                 times: Some(1),
                 verbose: false,
-                name: None,
+                name: None, silent: false,
             },
         ]
     })

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -319,7 +319,7 @@ impl Lovely {
         }
         let (patched, debug) = res.unwrap();
 
-        if !debug.entries.iter().all(|x| x.regions.is_empty()) {
+        if self.dump_all || !debug.entries.iter().all(|x| x.regions.is_empty()) {
             write_dump(
                 &self.mod_dir,
                 "game-dump",

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -319,15 +319,16 @@ impl Lovely {
         }
         let (patched, debug) = res.unwrap();
 
-        write_dump(
-            &self.mod_dir,
-            "game-dump",
-            &pretty_name,
-            &patched,
-            &PatchDebug::new(name),
-        );
-        write_dump(&self.mod_dir, "dump", &pretty_name, &patched, &debug);
-
+        if !debug.entries.iter().all(|x| x.regions.is_empty()) {
+            write_dump(
+                &self.mod_dir,
+                "game-dump",
+                &pretty_name,
+                &patched,
+                &PatchDebug::new(name),
+            );
+            write_dump(&self.mod_dir, "dump", &pretty_name, &patched, &debug);
+        }
         (self.loadbuffer)(state, patched.as_ptr(), patched.len(), name_ptr, mode_ptr)
     }
 }

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -17,9 +17,10 @@ use patch::{ModulePatch, Patch};
 use regex_lite::Regex;
 
 use sys::{check_lua_string, LuaFunc, LuaLib, LuaState, LuaStateTrait, LUA};
+use wildmatch::WildMatch;
 
+use crate::dump::{write_dump, PatchDebug};
 use crate::patch::Target;
-use crate::dump::{PatchDebug, write_dump};
 
 pub mod chunk_vec_cursor;
 pub mod dump;
@@ -311,14 +312,20 @@ impl Lovely {
 
         // Apply patches onto this buffer.
         let res = patch_table.apply_patches(name, buf_str, state);
-        if res.is_err() {
-            state.push(res.unwrap_err());
+        if let Err(err) = res {
+            state.push(err);
             // NOTE: Not really a great error but it doesn't handle the correcter errors right.
             return 3; // LUA_ERRSYNTAX
         }
         let (patched, debug) = res.unwrap();
 
-        write_dump(&self.mod_dir, "game-dump", &pretty_name, &patched, &PatchDebug::new(name));
+        write_dump(
+            &self.mod_dir,
+            "game-dump",
+            &pretty_name,
+            &patched,
+            &PatchDebug::new(name),
+        );
         write_dump(&self.mod_dir, "dump", &pretty_name, &patched, &debug);
 
         (self.loadbuffer)(state, patched.as_ptr(), patched.len(), name_ptr, mode_ptr)
@@ -336,9 +343,9 @@ unsafe extern "C" fn apply_patches(lua_state: *mut LuaState) -> c_int {
         let binding = RUNTIME.get().unwrap().patch_table.read().unwrap();
         if binding.needs_patching(&buf_name) {
             let res = binding.apply_patches(&buf_name, &buf, lua_state);
-            if res.is_err() {
+            if let Err(err) = res {
                 lua_state.push(false);
-                lua_state.push(res.unwrap_err());
+                lua_state.push(err);
                 num = 2;
                 return;
             }
@@ -360,19 +367,27 @@ unsafe extern "C" fn apply_patches(lua_state: *mut LuaState) -> c_int {
 impl Target {
     pub fn can_apply(&self, target: &str) -> bool {
         match self {
-            Self::Single(str) => str == target,
-            Self::Multi(strs) => strs.iter().any(|x| x == target),
+            Self::Single(str) => WildMatch::new(str).matches(target),
+            Self::Multi(strs) => strs.iter().any(|x| WildMatch::new(x).matches(target)),
         }
     }
 
-    pub fn insert_into(&self, targets: &mut HashSet<String>) {
+    pub fn insert_into(&self, targets: &mut (HashSet<String>, Vec<WildMatch>)) {
         match self {
             Self::Single(str) => {
-                targets.insert(str.clone());
+                if str.contains('?') || str.contains('*') {
+                    targets.1.push(WildMatch::new(str));
+                } else {
+                    targets.0.insert(str.clone());
+                }
             }
             Self::Multi(strs) => {
                 for target in strs.iter() {
-                    targets.insert(target.clone());
+                    if target.contains('?') || target.contains('*') {
+                        targets.1.push(WildMatch::new(target));
+                    } else {
+                        targets.0.insert(target.clone());
+                    }
                 }
             }
         }

--- a/crates/lovely-core/src/patch/pattern.rs
+++ b/crates/lovely-core/src/patch/pattern.rs
@@ -30,6 +30,11 @@ pub struct PatternPatch {
     #[serde(default)]
     pub overwrite: bool,
 
+    // Whether a warning will appear if the patch does not match anything.
+    // Overridden to true for targets that are simply "*"
+    #[serde(default)]
+    pub silent: bool,
+
     // Currently unused.
     pub name: Option<String>,
 }
@@ -97,7 +102,7 @@ impl PatternPatch {
             }
         }
 
-        if matches.is_empty() {
+        if matches.is_empty() && !self.silent {
             return Some(self.debug_from_warning_string(path, format!(
                 "Pattern '{}' on target '{target}' for pattern patch from {} resulted in no matches",
                 self.pattern.escape_debug(),

--- a/crates/lovely-core/src/patch/regex.rs
+++ b/crates/lovely-core/src/patch/regex.rs
@@ -32,6 +32,11 @@ pub struct RegexPatch {
     // by $index.
     pub payload: String,
 
+    // Whether a warning will appear if the patch does not match anything.
+    // Overridden to true for targets that are simply "*"
+    #[serde(default)]
+    pub silent: bool,
+
     // A string or Regex capture to prepend onto the start of each LINE of the payload.
     // This value defaults to an empty string.
     #[serde(default)]
@@ -85,7 +90,7 @@ impl RegexPatch {
             });
 
         let mut captures = re.captures_iter(input).collect_vec();
-        if captures.is_empty() {
+        if captures.is_empty() && !self.silent {
             let warning = format!("Regex '{}' on target '{target}' for regex patch from {} resulted in no matches", self.pattern.escape_debug(), path.display());
             return Some(self.debug_from_warning_string(path, warning));
         }


### PR DESCRIPTION
Allows the use of "*" and "?" in targets.

Veeeery hacky, had to change a lot of stuff. I think I got it all working without any log spam.

I added a new optional property to patterns and regexes, `silent`, suppressing the warning for a patch not applying to its target. This defaults to `false`, except when the target is exactly `*`.