### PR TITLE
fix: deadlock on reload in load_now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -705,6 +705,15 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "lockfree-object-pool"
@@ -732,6 +741,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "parking_lot",
  "regex-cursor",
  "regex-lite",
  "serde",
@@ -880,6 +890,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -1063,6 +1105,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/crates/lovely-core/Cargo.toml
+++ b/crates/lovely-core/Cargo.toml
@@ -23,6 +23,7 @@ itertools = "0.13.0"
 crop = "0.4.2"
 anyhow = "1.0.100"
 zip = "6.0.0"
+parking_lot = "0.12.5"
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false }

--- a/crates/lovely-core/src/lib.rs
+++ b/crates/lovely-core/src/lib.rs
@@ -5,9 +5,10 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::{c_int, CStr};
 use std::panic;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 use std::{env, fs};
+use std::time::Duration;
 
 use log::*;
 
@@ -15,6 +16,7 @@ use getargs::{Arg, Options};
 use itertools::Itertools;
 use patch::{ModulePatch, Patch};
 use regex_lite::Regex;
+use parking_lot::RwLock;
 
 use sys::{check_lua_string, LuaFunc, LuaLib, LuaState, LuaStateTrait, LUA};
 
@@ -46,16 +48,26 @@ unsafe extern "C" fn reload_patches(state: *mut LuaState) -> c_int {
         }
     };
     let binding = Arc::clone(&lovely.patch_table);
-    let mut patch_table = binding.write().unwrap();
-    *patch_table = new_table;
-    state.push(true);
-    1
+    let patch_table = binding.try_write_for(Duration::from_secs(1));
+
+    match patch_table {
+        Some(mut t) => {
+            *t = new_table;
+            state.push(true);
+            1
+        },
+        None => {
+            state.push(false);
+            state.push("Could not aquire lock in a reasonable time. Possible deadlock prevented.");
+            2
+        }
+    }
 }
 
 unsafe extern "C" fn getvar(state: *mut LuaState) -> c_int {
     let key = check_lua_string(state, 1);
     let lovely = &RUNTIME.get().unwrap();
-    let vars = lovely.lua_vars.read().unwrap();
+    let vars = lovely.lua_vars.read();
     let val = vars.get(&key);
     if let Some(val) = val {
         state.push(val);
@@ -68,7 +80,7 @@ unsafe extern "C" fn setvar(state: *mut LuaState) -> c_int {
     let key = check_lua_string(state, 1);
     let val = check_lua_string(state, 2);
     let lovely = &RUNTIME.get().unwrap();
-    let mut vars = lovely.lua_vars.write().unwrap();
+    let mut vars = lovely.lua_vars.write();
     vars.insert(key, val);
     0
 }
@@ -76,7 +88,7 @@ unsafe extern "C" fn setvar(state: *mut LuaState) -> c_int {
 unsafe extern "C" fn removevar(state: *mut LuaState) -> c_int {
     let key = check_lua_string(state, 1);
     let lovely = &RUNTIME.get().unwrap();
-    let mut vars = lovely.lua_vars.write().unwrap();
+    let mut vars = lovely.lua_vars.write();
     let val = vars.remove(&key);
     if let Some(val) = val {
         state.push(val);
@@ -247,7 +259,7 @@ impl Lovely {
     ) -> u32 {
         // Install native function overrides.
         let binding = Arc::clone(&self.patch_table);
-        let patch_table = binding.read().unwrap();
+        let patch_table = binding.read();
         {
             if !sys::is_module_preloaded(state, "lovely") {
                 let closure: LuaFunc = sys::override_print;
@@ -265,7 +277,7 @@ impl Lovely {
                         Patch::Module(patch) => Some((patch, prio, path)),
                         _ => None,
                     })
-                    .filter(|(x, _, _)| !x.load_now)
+                .filter(|(x, _, _)| !x.load_now)
                     .sorted_by_key(|(_, &prio, _)| prio)
                     .map(|(x, _, path)| (x, path))
                     .collect();
@@ -333,7 +345,7 @@ unsafe extern "C" fn apply_patches(lua_state: *mut LuaState) -> c_int {
     let buf = check_lua_string(lua_state, 2);
     let mut num = 1;
     let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        let binding = RUNTIME.get().unwrap().patch_table.read().unwrap();
+        let binding = RUNTIME.get().unwrap().patch_table.read();
         if binding.needs_patching(&buf_name) {
             let res = binding.apply_patches(&buf_name, &buf, lua_state);
             if res.is_err() {

--- a/crates/lovely-core/src/log.rs
+++ b/crates/lovely-core/src/log.rs
@@ -2,7 +2,6 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 use std::sync::{OnceLock, RwLock};
-
 use chrono::Local;
 
 // Exports for convenience.


### PR DESCRIPTION
Errors if lock could not be acquired in 1 second on reload_patches. To see: can this be too slow? (e.g. reloading on a different thread, loading buffers at the same time)