### PR TITLE
ci: add linux aarch64 build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,11 @@ jobs:
           ## [Install guide](https://github.com/ethangreen-dev/lovely-injector?tab=readme-ov-file#manual-installation)
           OS|Download|
           --|--|
-          Windows|[lovely-x86_64-pc-windows-msvc.zip](https://github.com/ethangreen-dev/lovely-injector/releases/download/${{ github.ref_name }}/lovely-x86_64-pc-windows-msvc.zip)|
-          Mac (Arm)|[lovely-aarch64-apple-darwin.tar.gz](https://github.com/ethangreen-dev/lovely-injector/releases/download/${{ github.ref_name }}/lovely-aarch64-apple-darwin.tar.gz)|
-          Mac (x86)|[lovely-x86_64-apple-darwin.tar.gz](https://github.com/ethangreen-dev/lovely-injector/releases/download/${{ github.ref_name }}/lovely-x86_64-apple-darwin.tar.gz)|
-          Linux|[lovely-x86_64-unknown-linux-gnu.tar.gz](https://github.com/ethangreen-dev/lovely-injector/releases/download/${{ github.ref_name }}/lovely-x86_64-unknown-linux-gnu.tar.gz)|
+          Windows|[lovely-x86_64-pc-windows-msvc.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/lovely-x86_64-pc-windows-msvc.zip)|
+          Mac (Arm)|[lovely-aarch64-apple-darwin.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/lovely-aarch64-apple-darwin.tar.gz)|
+          Mac (x86)|[lovely-x86_64-apple-darwin.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/lovely-x86_64-apple-darwin.tar.gz)|
+          Linux (x86)|[lovely-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/lovely-x86_64-unknown-linux-gnu.tar.gz)|
+          Linux (Arm)|[lovely-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/lovely-aarch64-unknown-linux-gnu.tar.gz)|
           EOF
 
           gh release create ${{ github.ref_name }} \
@@ -122,6 +123,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -134,16 +136,18 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-      - name: install gcc 14
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y g++-14
-
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 10
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 10
+          pip3 install ziglang==0.13.0.post1 cargo-zigbuild
 
       - name: Build
-        run: cargo build --target ${{ matrix.target }} --package lovely-unix --release
+        run: cargo zigbuild --target ${{ matrix.target }} --package lovely-unix --release
+        env:
+          SDKROOT: ""
 
       - name: Compress tar.gz
         run: |


### PR DESCRIPTION
Adds `aarch64-unknown-linux-gnu` to the `build-linux` matrix. Uses `cargo-zigbuild` for cross-compilation on the existing `ubuntu-latest` runner. No source code changes.

**New artifact:** `lovely-aarch64-unknown-linux-gnu.tar.gz`

CI tested on fork: [run #25866372077](https://github.com/S1M0N38/lovely-injector/actions/runs/25866372077) · [release](https://github.com/S1M0N38/lovely-injector/releases/tag/v0.9.0-add-linux-arm)

Note: Mac builds still fail in this branch (pre-existing issue addressed in a separate PR #364).

*PR 🤖 generated on behalf of @S1M0N38*