### PR TITLE
ci: fix mac builds by using native macos-latest runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         target:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,18 +90,8 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
-      - name: Install Mac SDK
-        run: |
-          curl -L "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.9.sdk.tar.xz" | tar -J -x -C /opt
-          curl -L "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz" | tar -J -x -C /opt
-          echo "SDKROOT=/opt/MacOSX11.3.sdk" >> $GITHUB_ENV
-
-      - name: Install cargo-zigbuild
-        run: |
-          pip3 install ziglang==0.13.0.post1 cargo-zigbuild
-
       - name: Build
-        run: cargo zigbuild --target ${{ matrix.target }} --package lovely-unix --release
+        run: cargo build --target ${{ matrix.target }} --package lovely-unix --release
 
       - name: Compress tar.gz
         run: |


### PR DESCRIPTION
Fixes the long-standing Mac CI failure by switching `build-mac` from broken cross-compilation on `ubuntu-latest` (via `cargo-zigbuild` + downloaded macOS SDKs) to native builds on `macos-latest`. No source code changes.

The upstream Mac CI has never succeeded — both v0.8.0 and v0.9.0 Release runs failed with `exit code 101` (`undefined symbol: _CodePatch` from Dobby's cmake cross-compile). Mac binaries were manually uploaded by @WilsontheWolf.

**Change:** `runs-on: ubuntu-latest` → `runs-on: macos-latest`, removes Mac SDK download + cargo-zigbuild install, uses plain `cargo build`.

CI tested on fork: [run #25866393197](https://github.com/S1M0N38/lovely-injector/actions/runs/25866393197) · [release](https://github.com/S1M0N38/lovely-injector/releases) — all 4 artifacts (Mac ARM, Mac x86, Linux x86, Windows x86) built and uploaded successfully.

*PR 🤖 generated on behalf of @S1M0N38*